### PR TITLE
회원가입 중복확인 코드 변경

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/config/security/SecurityConfig.java
+++ b/src/main/java/cord/eoeo/momentwo/config/security/SecurityConfig.java
@@ -28,7 +28,9 @@ public class SecurityConfig {
     private static final String[] WHITE_LIST = {
             "/signup",
             "/signin",
-            "/signout"
+            "/signout",
+            "/check_email",
+            "/check_nickname"
     };
 
     @Bean

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/EmailAvailabilityDto.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/EmailAvailabilityDto.java
@@ -1,0 +1,18 @@
+package cord.eoeo.momentwo.user.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailAvailabilityDto {
+    @NotBlank(message = "사용할 이메일를 입력해주세요.")
+    @Pattern(regexp = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$",
+            message = "이메일 형식을 지켜주세요.")
+    private String username;
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/NicknameAvailabilityDto.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/NicknameAvailabilityDto.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.user.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NicknameAvailabilityDto {
+    @NotBlank(message = "사용할 별명을 입력해주세요.")
+    private String nickname;
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/in/UserRegisterController.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/in/UserRegisterController.java
@@ -1,5 +1,7 @@
 package cord.eoeo.momentwo.user.adapter.in;
 
+import cord.eoeo.momentwo.user.adapter.dto.in.EmailAvailabilityDto;
+import cord.eoeo.momentwo.user.adapter.dto.in.NicknameAvailabilityDto;
 import cord.eoeo.momentwo.user.adapter.dto.in.UserRegisterRequestDto;
 import cord.eoeo.momentwo.user.application.port.in.UserRegisterUseCase;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,5 +20,17 @@ public class UserRegisterController {
     @ResponseStatus(HttpStatus.OK)
     public void register(@RequestBody @Valid UserRegisterRequestDto userRegisterRequestDto) {
         userRegisterUseCase.register(userRegisterRequestDto);
+    }
+
+    @PostMapping("/check_email")
+    @ResponseStatus(HttpStatus.OK)
+    public CompletableFuture<Void> checkEmailAvailability(@RequestBody @Valid EmailAvailabilityDto emailAvailabilityDto) {
+        return userRegisterUseCase.checkEmailAvailability(emailAvailabilityDto);
+    }
+
+    @PostMapping("/check_nickname")
+    @ResponseStatus(HttpStatus.OK)
+    public CompletableFuture<Void> checkNicknameAvailability(@RequestBody @Valid NicknameAvailabilityDto nicknameAvailabilityDto) {
+        return userRegisterUseCase.checkNicknameAvailability(nicknameAvailabilityDto);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/in/UserRegisterUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/in/UserRegisterUseCase.java
@@ -1,7 +1,17 @@
 package cord.eoeo.momentwo.user.application.port.in;
 
+import cord.eoeo.momentwo.user.adapter.dto.in.EmailAvailabilityDto;
+import cord.eoeo.momentwo.user.adapter.dto.in.NicknameAvailabilityDto;
 import cord.eoeo.momentwo.user.adapter.dto.in.UserRegisterRequestDto;
+
+import java.util.concurrent.CompletableFuture;
 
 public interface UserRegisterUseCase {
     void register(UserRegisterRequestDto userRegisterRequestDto);
+
+    // 지속적인 이메일 중복 유효성 확인
+    CompletableFuture<Void> checkEmailAvailability(EmailAvailabilityDto emailAvailabilityDto);
+
+    // 지속적인 별명 중복 유효성 확인
+    CompletableFuture<Void> checkNicknameAvailability(NicknameAvailabilityDto nicknameAvailabilityDto);
 }


### PR DESCRIPTION
### 회원가입 중복확인 코드 변경

#### 기존 방식
- 클라이언트가 회원가입을 누르면 서버에서 회원가입을 할 수 있는 유저인지 확인할 수 있었다.

#### 변경 방식
- 시간 간격을 두어 클라이언트가 회원가입 버튼을 누르지 않아도 실시간으로 이메일 및 별명에 대한 중복여부를 확인해
보다 유연하게 회원가입을 진행할 수 있도록 구현한다.

Resolve: #19 