### PR TITLE
멤버 패키지 구현

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/global/advice/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package cord.eoeo.momentwo.global.advice;
 
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.advice.exception.PasswordMisMatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,27 +7,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Objects;
-import java.util.concurrent.CompletionException;
 
 @RestControllerAdvice
-public class globalExceptionHandler {
+public class GlobalExceptionHandler {
     // DTO에서 패턴에 따른 예외처리 적용
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String dtoValidation(final MethodArgumentNotValidException e) {
         return Objects.requireNonNull(e.getFieldError()).getDefaultMessage();
-    }
-
-    // Async 핸들러
-    @ExceptionHandler(CompletionException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public void completionHandlerException(CompletionException ex) {
-        Throwable cause = ex.getCause();
-        if(cause instanceof NotFoundUserException) {
-            throw new NotFoundUserException();
-        }
-        else {
-            throw new PasswordMisMatchException();
-        }
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/AlbumMemberController.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/AlbumMemberController.java
@@ -1,0 +1,63 @@
+package cord.eoeo.momentwo.member.adapter.in;
+
+import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
+import cord.eoeo.momentwo.member.application.port.in.AlbumMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class AlbumMemberController {
+    private final AlbumMemberUseCase albumMemberUseCase;
+
+    // 멤버 초대
+    @PostMapping("/{albumId}/members/invite")
+    @ResponseStatus(HttpStatus.OK)
+    public void inviteMembers(@PathVariable long albumId,
+                             @RequestBody @Valid InviteMembersRequestDto inviteMembersRequestDto) {
+        albumMemberUseCase.inviteMembers(albumId, inviteMembersRequestDto);
+    }
+
+    // 멤버 조회
+    @GetMapping("/{albumId}/members")
+    @ResponseStatus(HttpStatus.OK)
+    public AlbumMemberResponseDto getMembers(@PathVariable long albumId) {
+        return albumMemberUseCase.getMembers(albumId);
+    }
+
+    // 멤버 추방
+    @DeleteMapping("/{albumId}/members/kick")
+    @ResponseStatus(HttpStatus.OK)
+    public void kickMembers(@PathVariable long albumId,
+                           @RequestBody @Valid KickMembersRequestDto kickMembersRequestDto) {
+        albumMemberUseCase.kickMembers(albumId, kickMembersRequestDto);
+    }
+
+    // 멤버 권한 변경 (앨범 수정 권한)
+    @PutMapping("/{albumId}/members/permission")
+    @ResponseStatus(HttpStatus.OK)
+    public void editMembersGrade(@PathVariable long albumId,
+                                                    @RequestBody @Valid EditGradeListRequestDto editGradeListRequestDto) {
+        albumMemberUseCase.editMembersGrade(albumId, editGradeListRequestDto);
+    }
+
+    // 관리자 권한 넘겨주기
+    @PutMapping("/{albumId}/members/assign/admin")
+    public void assignAdmin(@PathVariable long albumId,
+                            @RequestBody @Valid AssignAdminRequestDto assignAdminRequestDto) {
+        albumMemberUseCase.assignAdmin(albumId, assignAdminRequestDto);
+    }
+
+    // 멤버 나가기 (개인)
+    @DeleteMapping("/{albumId}/members/out")
+    public void outAlbum(@PathVariable long albumId) {
+        albumMemberUseCase.outAlbum(albumId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/AssignAdminRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/AssignAdminRequestDto.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.member.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AssignAdminRequestDto {
+    @NotBlank(message = "별명을 입력해주세요.")
+    private String nickname;
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/EditGradeListRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/EditGradeListRequestDto.java
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.member.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.HashMap;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class EditGradeListRequestDto {
+    @NotEmpty(message = "권한 변경을 위한 입력이 올바르지 않습니다.")
+    private HashMap<String, String> editMemberList;
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/InviteMembersRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/InviteMembersRequestDto.java
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.member.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InviteMembersRequestDto {
+    @NotEmpty(message = "초대할 유저 닉네임을 하나이상 입력해주세요.")
+    private List<String> inviteUsernames;
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/KickMembersRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/KickMembersRequestDto.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.member.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class KickMembersRequestDto {
+    private List<String> kickMemberList;
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberInviteImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberInviteImpl.java
@@ -1,0 +1,31 @@
+package cord.eoeo.momentwo.member.adapter.out;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberInvite;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberRepository;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumMemberInviteImpl implements AlbumMemberInvite {
+    private final AlbumMemberRepository albumMemberRepository;
+
+    // 멤버 초대하기
+    @Override
+    @Transactional
+    @Async
+    public CompletableFuture<Void> invite(Album album, User invitedUser) {
+        return CompletableFuture.runAsync(() -> {
+            Member newMember = new Member(invitedUser, album, MemberAlbumGrade.ROLE_ALBUM_COMMON_MEMBER);
+            albumMemberRepository.save(newMember);
+        });
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
@@ -1,0 +1,46 @@
+package cord.eoeo.momentwo.member.adapter.out;
+
+import cord.eoeo.momentwo.member.advice.exception.NotFoundAccessException;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberJpaRepository;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberRepository;
+import cord.eoeo.momentwo.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class AlbumMemberRepositoryImpl implements AlbumMemberRepository {
+    private final AlbumMemberJpaRepository albumMemberJpaRepository;
+
+    @Override
+    public void save(Member member) {
+        albumMemberJpaRepository.save(member);
+    }
+
+    @Override
+    public List<String> findNicknameByAlbum(long albumId) {
+        return albumMemberJpaRepository.findNicknameByAlbum(albumId);
+    }
+
+    @Override
+    public Member findMemberGradeByAlbumIdAndUserId(long albumId, long userId) {
+        return albumMemberJpaRepository.findMemberGradeByAlbumIdAndUserId(albumId, userId)
+                .orElseThrow(NotFoundAccessException::new);
+    }
+
+    @Override
+    public List<String> getAllNicknameList(long albumId) {
+        return albumMemberJpaRepository.getAllNicknameList(albumId);
+    }
+
+    public void deleteById(long id) {
+        albumMemberJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public int deleteByAlbumIdAndUserId(long albumId, long userId) {
+        return albumMemberJpaRepository.deleteByAlbumIdAndUserId(albumId, userId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
@@ -1,0 +1,112 @@
+package cord.eoeo.momentwo.member.adapter.out;
+
+import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
+import cord.eoeo.momentwo.album.application.port.out.AlbumRepository;
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.advice.exception.NotChangeSameAndUpGradeRulesException;
+import cord.eoeo.momentwo.member.advice.exception.NotFoundAuthorityException;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberRepository;
+import cord.eoeo.momentwo.member.application.port.out.GetAlbumInfo;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Configuration
+@RequiredArgsConstructor
+public class GetAlbumInfoImpl implements GetAlbumInfo {
+    private final AlbumRepository albumRepository;
+    private final AlbumMemberRepository albumMemberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    @Async
+    public CompletableFuture<Album> getAlbum(long id) {
+        return CompletableFuture.supplyAsync(()
+                -> albumRepository.findById(id).orElseThrow(NotFoundAlbumException::new));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void checkAuthorityAdmin(long albumId, long userId) {
+        Member member = albumMemberRepository.findMemberGradeByAlbumIdAndUserId(albumId, userId);
+        if(member.getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN)
+                || member.getRules().equals(MemberAlbumGrade.ROLE_ALBUM_SUB_ADMIN)) {
+            return;
+        }
+        throw new NotFoundAuthorityException();
+    }
+
+    @Override
+    @Transactional
+    public void editGrade(long albumId, long userId, String rules) {
+        Member editMember = albumMemberRepository.findMemberGradeByAlbumIdAndUserId(albumId, userId);
+        editMember.setRules(MemberAlbumGrade.findMemberAlbumGrade(rules));
+        albumMemberRepository.save(editMember);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> getAlbumMemberList(long albumId) {
+        return albumMemberRepository.getAllNicknameList(albumId);
+    }
+
+    // 멤버 권한 확인 후 변경
+    @Override
+    @Transactional(readOnly = true)
+    public void changeRules(long albumId, User owner, User target, String rules) {
+        Member ownerMember = getAlbumMemberInfo(albumId, owner.getId());
+        Member targetMember = getAlbumMemberInfo(albumId, target.getId());
+
+        // 우선순위 비교
+        if(ownerMember.getRules().getPriority() <= MemberAlbumGrade.findMemberAlbumGrade(rules).getPriority()) {
+            throw new NotChangeSameAndUpGradeRulesException();
+        }
+
+        if(ownerMember.getRules().getPriority() < targetMember.getRules().getPriority()) {
+            editGrade(albumId, target.getId(), rules);
+        }
+    }
+
+    // 앨범 멤버 정보 가져오기
+    @Override
+    @Transactional(readOnly = true)
+    public Member getAlbumMemberInfo(long albumId, long userId) {
+        return albumMemberRepository.findMemberGradeByAlbumIdAndUserId(albumId, userId);
+    }
+
+    // 멤버 추방 (권한 비교 후)
+    @Override
+    @Transactional
+    public void doKickMember(long albumId, User owner, User kickedUser) {
+        Member ownerMember = getAlbumMemberInfo(albumId, owner.getId());
+        Member kickedMember = getAlbumMemberInfo(albumId, kickedUser.getId());
+
+        if(ownerMember.getRules().getPriority() < kickedMember.getRules().getPriority()) {
+            albumMemberRepository.deleteById(kickedMember.getId());
+        }
+    }
+
+    // 관리자 권한 넘기기
+    @Override
+    @Transactional
+    public void assignAdmin(long albumId, User changeUser, MemberAlbumGrade rules) {
+        Member changeMember = albumMemberRepository.findMemberGradeByAlbumIdAndUserId(albumId, changeUser.getId());
+        changeMember.setRules(rules);
+        albumMemberRepository.save(changeMember);
+    }
+
+    // 앨범에 속해 있다면 나가기
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isAlbumOut(long albumId, User selfUser) {
+        int albumOut = albumMemberRepository.deleteByAlbumIdAndUserId(albumId, selfUser.getId());
+        return albumOut > 0;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetMemberInfoImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetMemberInfoImpl.java
@@ -1,0 +1,34 @@
+package cord.eoeo.momentwo.member.adapter.out;
+
+import cord.eoeo.momentwo.member.application.port.out.GetMemberInfo;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.application.port.out.UserRepository;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CompletableFuture;
+
+@Configuration
+@RequiredArgsConstructor
+public class GetMemberInfoImpl implements GetMemberInfo {
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    @Async
+    public CompletableFuture<User> getUserInfo(String username) {
+        return CompletableFuture.supplyAsync(()
+                -> userRepository.findByUsername(username).orElseThrow(NotFoundUserException::new));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @Async
+    public CompletableFuture<User> getUserInfoByNickname(String nickname) {
+        return CompletableFuture.supplyAsync(()
+                -> userRepository.findByNickname(nickname).orElseThrow(NotFoundUserException::new));
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/AlbumMemberResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/AlbumMemberResponseDto.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.member.adapter.out.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumMemberResponseDto {
+    private List<MemberResponseDto> albumMember;
+
+    public AlbumMemberResponseDto toDo(List<String> albumMember) {
+        return new AlbumMemberResponseDto(
+                albumMember.stream().map(nickname -> new MemberResponseDto().toDo(nickname)).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/MemberResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/MemberResponseDto.java
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.member.adapter.out.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberResponseDto {
+    private String nickname;
+
+    public MemberResponseDto toDo(String nickname) {
+        return new MemberResponseDto(nickname);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/MemberExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/MemberExceptionHandler.java
@@ -1,0 +1,64 @@
+package cord.eoeo.momentwo.member.advice;
+
+import cord.eoeo.momentwo.member.advice.exception.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MemberExceptionHandler {
+    @ExceptionHandler(NotFoundAuthorityException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notFoundAuthorityException() {
+        return "권한이 없는 유저입니다.";
+    }
+
+    @ExceptionHandler(NotFoundAccessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notFoundAccessException() {
+        return "해당 앨범에 접근 권한이 없는 유저입니다.";
+    }
+
+    @ExceptionHandler(NotFoundGradeException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notFoundGradeException() {
+        return "권한 입력이 올바르지 않습니다.";
+    }
+
+    @ExceptionHandler(NotChangeSelfException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notChangeSelfException() {
+        return "본인 스스로 권한을 변경할 수 없습니다.";
+    }
+
+    @ExceptionHandler(NotChangeSameAndUpGradeRulesException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notChangeSameAndUpGradeRulesException() {
+        return "본인과 크거나 같은 권한은 변경할 수 없습니다.";
+    }
+
+    @ExceptionHandler(NotChangeAdminException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notChangeAdminException() {
+        return "관리자가 아니기 때문에 변경할 수 없습니다.";
+    }
+
+    @ExceptionHandler(NotSelfKickException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notSelfKickException() {
+        return "본인을 추방하기 위해선 앨범 나가기를 해야합니다.";
+    }
+
+    @ExceptionHandler(AdminAlbumOutException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String adminAlbumOutException() {
+        return "앨범에 멤버가 존재하기 때문에 관리자는 나갈 수 없습니다.\r\n나가길 원할 경우 관리자 권한을 넘겨주십시오.";
+    }
+
+    @ExceptionHandler(MemberNotInAlbumException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String memberNotInAlbumException() {
+        return "앨범 멤버만 나갈 수 있습니다.";
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/AdminAlbumOutException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/AdminAlbumOutException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class AdminAlbumOutException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/MemberNotInAlbumException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/MemberNotInAlbumException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class MemberNotInAlbumException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeAdminException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeAdminException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotChangeAdminException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeSameAndUpGradeRulesException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeSameAndUpGradeRulesException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotChangeSameAndUpGradeRulesException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeSelfException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotChangeSelfException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotChangeSelfException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundAccessException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundAccessException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotFoundAccessException extends RuntimeException {
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundAuthorityException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundAuthorityException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotFoundAuthorityException extends RuntimeException {
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundGradeException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotFoundGradeException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotFoundGradeException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotSelfKickException.java
+++ b/src/main/java/cord/eoeo/momentwo/member/advice/exception/NotSelfKickException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.member.advice.exception;
+
+public class NotSelfKickException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/in/AlbumMemberUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/in/AlbumMemberUseCase.java
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.member.application.port.in;
+
+import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
+
+public interface AlbumMemberUseCase {
+    void inviteMembers(long albumId, InviteMembersRequestDto inviteMembersRequestDto);
+
+    // 멤버 조회
+    AlbumMemberResponseDto getMembers(long albumId);
+
+    // 멤버 추방
+    void kickMembers(long albumId, KickMembersRequestDto kickMembersRequestDto);
+
+    // 멤버 권한 변경 (앨범 수정 권한)
+    void editMembersGrade(long albumId, EditGradeListRequestDto editGradeListRequestDto);
+
+    // 관리자 권한 넘기기
+    void assignAdmin(long albumId, AssignAdminRequestDto assignAdminRequestDto);
+
+    // 멤버 나가기 (개인)
+    void outAlbum(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberInvite.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberInvite.java
@@ -1,0 +1,10 @@
+package cord.eoeo.momentwo.member.application.port.out;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.user.domain.User;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface AlbumMemberInvite {
+    CompletableFuture<Void> invite(Album album, User invitedUser);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.member.application.port.out;
+
+import cord.eoeo.momentwo.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AlbumMemberJpaRepository extends JpaRepository<Member, Long> {
+    @Query("SELECT u.nickname FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId")
+    List<String> findNicknameByAlbum(long albumId);
+
+    @Query("SELECT m FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId and u.id = :userId")
+    Optional<Member> findMemberGradeByAlbumIdAndUserId(long albumId, long userId);
+
+    @Query("SELECT u.nickname FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId")
+    List<String> getAllNicknameList(long albumId);
+
+    void deleteById(long id);
+
+    @Modifying
+    @Query("DELETE FROM Member m WHERE m.album.id = :albumId AND m.user.id = :userId")
+    int deleteByAlbumIdAndUserId(long albumId, long userId);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.member.application.port.out;
+
+import cord.eoeo.momentwo.member.domain.Member;
+
+import java.util.List;
+
+public interface AlbumMemberRepository {
+    void save(Member member);
+
+    List<String> findNicknameByAlbum(long albumId);
+
+    Member findMemberGradeByAlbumIdAndUserId(long albumId, long userId);
+
+    List<String> getAllNicknameList(long albumId);
+
+    void deleteById(long id);
+
+    int deleteByAlbumIdAndUserId(long albumId, long userId);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetAlbumInfo.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetAlbumInfo.java
@@ -1,0 +1,31 @@
+package cord.eoeo.momentwo.member.application.port.out;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.domain.User;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface GetAlbumInfo {
+    CompletableFuture<Album> getAlbum(long id);
+
+    // 관리자급 권한 유저인지 확인
+    void checkAuthorityAdmin(long albumId, long userId);
+
+    // 앨범 접근 권한 변경
+    void editGrade(long albumId, long userId, String rules);
+
+    List<String> getAlbumMemberList(long albumId);
+
+    void changeRules(long albumId, User owner, User target, String rules);
+
+    Member getAlbumMemberInfo(long albumId, long userId);
+
+    void doKickMember(long albumId, User owner, User kickedUser);
+
+    void assignAdmin(long albumId, User changeUser, MemberAlbumGrade rules);
+
+    boolean isAlbumOut(long albumId, User selfUser);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetMemberInfo.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetMemberInfo.java
@@ -1,0 +1,10 @@
+package cord.eoeo.momentwo.member.application.port.out;
+
+import cord.eoeo.momentwo.user.domain.User;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface GetMemberInfo {
+    CompletableFuture<User> getUserInfo(String username);
+    CompletableFuture<User> getUserInfoByNickname(String nickname);
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
@@ -1,0 +1,139 @@
+package cord.eoeo.momentwo.member.application.service;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
+import cord.eoeo.momentwo.member.advice.exception.*;
+import cord.eoeo.momentwo.member.application.port.in.AlbumMemberUseCase;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberInvite;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberRepository;
+import cord.eoeo.momentwo.member.application.port.out.GetAlbumInfo;
+import cord.eoeo.momentwo.member.application.port.out.GetMemberInfo;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumMemberService implements AlbumMemberUseCase {
+    private final AlbumMemberRepository albumMemberRepository;
+    private final AlbumMemberInvite albumMemberInvite;
+    private final GetAlbumInfo getAlbumInfo;
+    private final GetMemberInfo getMemberInfo;
+    private final GetAuthentication getAuthentication;
+
+    @Override
+    @Transactional
+    public void inviteMembers(long albumId, InviteMembersRequestDto inviteMembersRequestDto) {
+        Album album = getAlbumInfo.getAlbum(albumId).join();
+
+        // 이미 앨범에 포함된 멤버
+        List<String> existMember = getAlbumInfo.getAlbumMemberList(albumId);
+
+        // 요청 보내기
+        inviteMembersRequestDto.getInviteUsernames().forEach(nickname -> {
+            User inviteUser = getMemberInfo.getUserInfoByNickname(nickname).join();
+            doInvite(album, inviteUser, existMember);
+        });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AlbumMemberResponseDto getMembers(long albumId) {
+        return new AlbumMemberResponseDto().toDo(albumMemberRepository.findNicknameByAlbum(albumId));
+    }
+
+    @Override
+    @Transactional
+    public void kickMembers(long albumId, KickMembersRequestDto kickMembersRequestDto) {
+        User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
+        getAlbumInfo.checkAuthorityAdmin(albumId, owner.getId());
+
+        // 자신 스스로 추방하려 할 경우
+        if(kickMembersRequestDto.getKickMemberList().contains(owner.getNickname())) {
+            throw new NotSelfKickException();
+        }
+
+        // 앨범 멤버에 포함되는지 확인
+        kickMembersRequestDto.getKickMemberList().forEach(nickname -> {
+            User kickedUser = getMemberInfo.getUserInfoByNickname(nickname).join();
+
+            // 본인보다 낮은 권한만 추방 가능
+            getAlbumInfo.doKickMember(albumId, owner, kickedUser);
+        });
+
+    }
+
+    @Override
+    @Transactional
+    public void editMembersGrade(long albumId, EditGradeListRequestDto editGradeListRequestDto) {
+        // 권한 변경자의 등급을 확인한다.
+        User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
+        getAlbumInfo.checkAuthorityAdmin(albumId, owner.getId());
+
+        // 호스트가 자신의 권한을 변경하려 할 경우
+        if(editGradeListRequestDto.getEditMemberList().containsKey(owner.getNickname())) {
+            throw new NotChangeSelfException();
+        }
+
+        // 리스트 안에 유저들이 바꿀 수 있는 값인지 확인 후
+        // 권한을 변경시킨다.
+        editGradeListRequestDto.getEditMemberList().forEach((nickname, rules) -> {
+            User target = getMemberInfo.getUserInfoByNickname(nickname).join();
+            getAlbumInfo.changeRules(albumId, owner, target, rules);
+        });
+    }
+
+    @Override
+    @Transactional
+    public void assignAdmin(long albumId, AssignAdminRequestDto assignAdminRequestDto) {
+        User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
+
+        // 관리자가 아닐경우
+        if(!getAlbumInfo.getAlbumMemberInfo(albumId,
+                owner.getId()).getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN)) {
+            throw new NotChangeAdminException();
+        }
+        User changeUser = getMemberInfo.getUserInfoByNickname(assignAdminRequestDto.getNickname()).join();
+        // 관리자 -> 일반 멤버
+        getAlbumInfo.assignAdmin(albumId, owner, MemberAlbumGrade.ROLE_ALBUM_COMMON_MEMBER);
+        // 일반 멤버 -> 관리자
+        getAlbumInfo.assignAdmin(albumId, changeUser, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+    }
+
+    @Override
+    @Transactional
+    public void outAlbum(long albumId) {
+        User selfUser = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
+
+        // 앨범 관리자가 나갈 경우 멤버가 존재한다면 나갈 수 없음
+        // 하지만 멤버가 없을 경우 나갈 수 있음
+        if(getAlbumInfo.getAlbumMemberInfo(albumId,
+                selfUser.getId()).getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN) &&
+                !getAlbumInfo.getAlbumMemberList(albumId).isEmpty()) {
+            throw new AdminAlbumOutException();
+        }
+
+        // 본인이 앨범에 속해있는지 확인한다.
+        // 삭제 된 행이 있으면 true, 없으면 false 반환
+        if(!getAlbumInfo.isAlbumOut(albumId, selfUser)) {
+            throw new MemberNotInAlbumException();
+        }
+    }
+
+    // 멤버 초대
+    @Transactional(readOnly = true)
+    private void doInvite(Album album, User inviteUser, List<String> existMember) {
+        if(!existMember.contains(inviteUser.getNickname())) {
+            albumMemberInvite.invite(album, inviteUser).join();
+        }
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/domain/Member.java
+++ b/src/main/java/cord/eoeo/momentwo/member/domain/Member.java
@@ -1,0 +1,52 @@
+package cord.eoeo.momentwo.member.domain;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.concurrent.CompletableFuture;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @DateTimeFormat(pattern = "yyyy-mm-dd")
+    private LocalDate joinDate;
+
+    @PrePersist
+    public void initDate() {
+        this.joinDate = LocalDate.now();
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "userId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "albumId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Album album;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberAlbumGrade rules;
+
+    public Member(User user, Album album, MemberAlbumGrade rules) {
+        this.user = user;
+        this.album = album;
+        this.rules = rules;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/member/domain/MemberAlbumGrade.java
+++ b/src/main/java/cord/eoeo/momentwo/member/domain/MemberAlbumGrade.java
@@ -1,0 +1,29 @@
+package cord.eoeo.momentwo.member.domain;
+
+import cord.eoeo.momentwo.member.advice.exception.NotFoundGradeException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+public enum MemberAlbumGrade {
+    ROLE_ALBUM_ADMIN("ROLE_ALBUM_ADMIN", 1), // 관리자
+    ROLE_ALBUM_SUB_ADMIN("ROLE_ALBUM_SUB_ADMIN", 2), // 부관리자
+    ROLE_ALBUM_COMMON_MEMBER("ROLE_ALBUM_COMMON_MEMBER", 3); // 일반멤버
+
+    private String albumGrade;
+
+    @Getter
+    private int priority;
+
+    MemberAlbumGrade(String albumGrade, int priority) {
+        this.albumGrade = albumGrade;
+        this.priority = priority;
+    }
+
+    public static MemberAlbumGrade findMemberAlbumGrade(String keyCode) {
+        return Arrays.stream(MemberAlbumGrade.values())
+                .filter(albumGrade -> albumGrade.name().equals(keyCode))
+                .findAny()
+                .orElseThrow(NotFoundGradeException::new);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/UserRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/UserRepositoryImpl.java
@@ -42,4 +42,9 @@ public class UserRepositoryImpl implements UserRepository {
     public boolean existsByNickname(String nickname) {
         return userJpaRepository.existsByNickname(nickname);
     }
+
+    @Override
+    public Optional<User> findByNickname(String nickname) {
+        return userJpaRepository.findByNickname(nickname);
+    }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/UserJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/UserJpaRepository.java
@@ -11,4 +11,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/UserRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository {
     boolean existsByUsername(String username);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }


### PR DESCRIPTION
### Fix
- 글로벌 예외처리 수정 (비동기 예외처리 삭제)

### Feat
- 유저 레포 (별명으로 데이터 찾기 추가)

### 멤버 패키지 구현

####작업내용
- 멤버 초대
- 멤버 조회
- 멤버 추방 
- 멤버 권한 변경 (앨범 수정 권한)
- 멤버 나가기 (개인)
- 멤버 권한이 마스터일 경우 불가

#### 추가사항
- 관리자 권한넘기기 추가

Resolve: #22 