### PR TITLE
앨범 조회 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
@@ -20,8 +20,8 @@ public class AlbumMemberRepositoryImpl implements AlbumMemberRepository {
     }
 
     @Override
-    public List<String> findNicknameByAlbum(long albumId) {
-        return albumMemberJpaRepository.findNicknameByAlbum(albumId);
+    public List<Member> findMemberByAlbum(long albumId) {
+        return albumMemberJpaRepository.findMemberByAlbum(albumId);
     }
 
     @Override

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/AlbumMemberResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/AlbumMemberResponseDto.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.member.adapter.out.dto;
 
+import cord.eoeo.momentwo.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,9 +14,10 @@ import java.util.stream.Collectors;
 public class AlbumMemberResponseDto {
     private List<MemberResponseDto> albumMember;
 
-    public AlbumMemberResponseDto toDo(List<String> albumMember) {
+    public AlbumMemberResponseDto toDo(List<Member> albumMember) {
         return new AlbumMemberResponseDto(
-                albumMember.stream().map(nickname -> new MemberResponseDto().toDo(nickname)).collect(Collectors.toList())
+                albumMember.stream().map(member -> new MemberResponseDto().toDo(member))
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/MemberResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/dto/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.member.adapter.out.dto;
 
+import cord.eoeo.momentwo.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +10,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberResponseDto {
     private String nickname;
+    private String rules;
 
-    public MemberResponseDto toDo(String nickname) {
-        return new MemberResponseDto(nickname);
+    public MemberResponseDto toDo(Member member) {
+        return new MemberResponseDto(
+                member.getUser().getNickname(),
+                member.getRules().toString()
+        );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
@@ -9,8 +9,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AlbumMemberJpaRepository extends JpaRepository<Member, Long> {
-    @Query("SELECT u.nickname FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId")
-    List<String> findNicknameByAlbum(long albumId);
+    @Query("SELECT m FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId")
+    List<Member> findMemberByAlbum(long albumId);
 
     @Query("SELECT m FROM Member m JOIN m.user u JOIN m.album a WHERE a.id = :albumId and u.id = :userId")
     Optional<Member> findMemberGradeByAlbumIdAndUserId(long albumId, long userId);

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface AlbumMemberRepository {
     void save(Member member);
 
-    List<String> findNicknameByAlbum(long albumId);
+    List<Member> findMemberByAlbum(long albumId);
 
     Member findMemberGradeByAlbumIdAndUserId(long albumId, long userId);
 

--- a/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
@@ -55,7 +55,15 @@ public class AlbumMemberService implements AlbumMemberUseCase {
     @Override
     @Transactional(readOnly = true)
     public AlbumMemberResponseDto getMembers(long albumId) {
-        return new AlbumMemberResponseDto().toDo(albumMemberRepository.findNicknameByAlbum(albumId));
+        User user = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
+
+        if(!getAlbumInfo.getAlbumMemberList(albumId).contains(user.getNickname())) {
+            throw new NotFoundAccessException();
+        }
+
+        return new AlbumMemberResponseDto().toDo(
+                albumMemberRepository.findMemberByAlbum(albumId)
+        );
     }
 
     @Override


### PR DESCRIPTION
### 앨범 조회 수정

- 기존에 조회 시 앨범에 속한 멤버만 조회가 가능하도록 설계하려 하였으나, 멤버가 아닌 유저도 조회할 수 있는 현상을 발견하여 수정
- 또한 반환 값에 권한을 함께 추가하여 리턴
- 권한이 없는 유저가 접근 시 예외처리

Resolve: #29 