### PR TITLE
앨범 생성 시 멤버 초대와 본인 권한 넣기 추가

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumCreateRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumCreateRequestDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -12,4 +13,5 @@ import javax.validation.constraints.NotBlank;
 public class AlbumCreateRequestDto {
     @NotBlank(message = "앨범 제목을 입력해주세요.")
     private String createTitle;
+    private List<String> doInviteNicknameList;
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
@@ -6,6 +6,12 @@ import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import cord.eoeo.momentwo.album.application.port.in.AlbumUseCase;
 import cord.eoeo.momentwo.album.application.port.out.AlbumRepository;
 import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberInvite;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
+import cord.eoeo.momentwo.user.application.port.out.UserRepository;
+import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +20,27 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AlbumService implements AlbumUseCase {
     private final AlbumRepository albumRepository;
+    private final AlbumMemberInvite albumMemberInvite;
+    private final UserRepository userRepository;
+    private final GetAuthentication getAuthentication;
 
     @Transactional
     @Override
     public void createAlbums(AlbumCreateRequestDto albumCreateRequestDto) {
+        User admin = userRepository.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        // 앨범 생성
         Album newAlbum = new Album(albumCreateRequestDto.getCreateTitle());
         albumRepository.save(newAlbum);
+
+        // 앨범 생성자 관리자 권한 부여
+        albumMemberInvite.invite(newAlbum, admin, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+
+        // 앨범에 초대된 멤버 권한 부여
+        albumCreateRequestDto.getDoInviteNicknameList().forEach(nickname -> {
+            User inviteUser = userRepository.findByNickname(nickname).orElseThrow();
+            albumMemberInvite.invite(newAlbum, inviteUser);
+        });
     }
 
     @Transactional

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberInviteImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberInviteImpl.java
@@ -28,4 +28,15 @@ public class AlbumMemberInviteImpl implements AlbumMemberInvite {
             albumMemberRepository.save(newMember);
         });
     }
+
+    // 멤버 초대하기 (초대하면서 권한을 부여하고 싶을 때)
+    @Override
+    @Transactional
+    @Async
+    public CompletableFuture<Void> invite(Album album, User invitedUser, MemberAlbumGrade rules) {
+        return CompletableFuture.runAsync(() -> {
+            Member member = new Member(invitedUser, album, rules);
+            albumMemberRepository.save(member);
+        });
+    }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberInvite.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberInvite.java
@@ -1,10 +1,12 @@
 package cord.eoeo.momentwo.member.application.port.out;
 
 import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
 import cord.eoeo.momentwo.user.domain.User;
 
 import java.util.concurrent.CompletableFuture;
 
 public interface AlbumMemberInvite {
     CompletableFuture<Void> invite(Album album, User invitedUser);
+    CompletableFuture<Void> invite(Album album, User invitedUser, MemberAlbumGrade rules);
 }


### PR DESCRIPTION
### 앨범 생성 시 멤버 초대와 본인 권한 넣기 추가

- 앨범 생성을 진행하면 앨범을 생성한 사람에게 관리자 권한을 부여
- 앨범 생성을 진행하면서 친구목록을 조회하고 선택한 친구들을 앨범을 만듬과 동시에 초대
- 친구 목록에 선택한 친구가 없어도 앨범을 생성할 수 있게 함

Resolve: #43 