### PR TITLE
앨범 패키지 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/out/AlbumManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/out/AlbumManagerImpl.java
@@ -1,0 +1,60 @@
+package cord.eoeo.momentwo.album.adapter.out;
+
+import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
+import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
+import cord.eoeo.momentwo.album.application.port.out.AlbumRepository;
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.application.port.out.AlbumMemberInvite;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumManagerImpl implements AlbumManager {
+    private final AlbumMemberInvite albumMemberInvite;
+    private final AlbumRepository albumRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Album getAlbumInfo(long id) {
+        return albumRepository.findById(id).orElseThrow(NotFoundAlbumException::new);
+    }
+
+    @Override
+    @Transactional
+    public void albumSave(Album album) {
+        albumRepository.save(album);
+    }
+
+    @Override
+    @Transactional
+    public void albumSetAdmin(Album album, User admin) {
+        albumMemberInvite.invite(album, admin, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+    }
+
+    @Override
+    @Transactional
+    public void albumAddMember(Album album, User inviteUser) {
+        albumMemberInvite.invite(album, inviteUser);
+    }
+
+    @Transactional
+    @CheckAlbumAdmin
+    @Override
+    public void albumEdit(Member member, String editTitle) {
+        member.getAlbum().setTitle(editTitle);
+        albumRepository.save(member.getAlbum());
+    }
+
+    @Transactional
+    @CheckAlbumAdmin
+    @Override
+    public void albumDelete(Member member) {
+        albumRepository.deleteAlbum(member.getAlbum().getId());
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/album/advice/AlbumExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/album/advice/AlbumExceptionHandler.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.album.advice;
 
+import cord.eoeo.momentwo.album.advice.exception.NotAlbumAdminException;
 import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,5 +13,11 @@ public class AlbumExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String notFoundAlbumException() {
         return "앨범이 존재하지 않습니다.";
+    }
+
+    @ExceptionHandler(NotAlbumAdminException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String notAlbumAdminException() {
+        return "앨범 관리자만 해당 기능을 사용할 수 있습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/advice/exception/NotAlbumAdminException.java
+++ b/src/main/java/cord/eoeo/momentwo/album/advice/exception/NotAlbumAdminException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.album.advice.exception;
+
+public class NotAlbumAdminException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/aop/CheckAlbumAdminAspect.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/aop/CheckAlbumAdminAspect.java
@@ -1,0 +1,31 @@
+package cord.eoeo.momentwo.album.application.aop;
+
+import cord.eoeo.momentwo.album.advice.exception.NotAlbumAdminException;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class CheckAlbumAdminAspect {
+
+    @After("@annotation(cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin)")
+    public void checkAlbumAdmin(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+
+        Member member = null;
+
+        for (int i = 0; i < args.length; i++) {
+            if (args[i] instanceof Member) {
+                member = (Member) args[i];
+            }
+        }
+
+        if(member != null && !member.getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN)) {
+            throw new NotAlbumAdminException();
+        }
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/aop/annotation/CheckAlbumAdmin.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/aop/annotation/CheckAlbumAdmin.java
@@ -1,0 +1,11 @@
+package cord.eoeo.momentwo.album.application.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CheckAlbumAdmin {
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/port/out/AlbumManager.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/port/out/AlbumManager.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.album.application.port.out;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.user.domain.User;
+
+public interface AlbumManager {
+    Album getAlbumInfo(long id);
+
+    void albumSave(Album album);
+
+    void albumSetAdmin(Album album, User admin);
+
+    void albumAddMember(Album album, User inviteUser);
+
+    void albumEdit(Member member, String editTitle);
+
+    void albumDelete(Member member);
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
@@ -2,13 +2,13 @@ package cord.eoeo.momentwo.album.application.service;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumCreateRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumTitleEditRequestDto;
-import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import cord.eoeo.momentwo.album.application.port.in.AlbumUseCase;
-import cord.eoeo.momentwo.album.application.port.out.AlbumRepository;
+import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
 import cord.eoeo.momentwo.album.domain.Album;
-import cord.eoeo.momentwo.member.application.port.out.AlbumMemberInvite;
-import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.member.application.port.out.GetAlbumInfo;
+import cord.eoeo.momentwo.member.domain.Member;
 import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.advice.exception.NotInviteUserException;
 import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
 import cord.eoeo.momentwo.user.application.port.out.UserRepository;
 import cord.eoeo.momentwo.user.domain.User;
@@ -19,10 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class AlbumService implements AlbumUseCase {
-    private final AlbumRepository albumRepository;
-    private final AlbumMemberInvite albumMemberInvite;
     private final UserRepository userRepository;
     private final GetAuthentication getAuthentication;
+    private final GetAlbumInfo getAlbumInfo;
+    private final AlbumManager albumManager;
 
     @Transactional
     @Override
@@ -31,29 +31,38 @@ public class AlbumService implements AlbumUseCase {
                 .orElseThrow(NotFoundUserException::new);
         // 앨범 생성
         Album newAlbum = new Album(albumCreateRequestDto.getCreateTitle());
-        albumRepository.save(newAlbum);
+        albumManager.albumSave(newAlbum);
 
         // 앨범 생성자 관리자 권한 부여
-        albumMemberInvite.invite(newAlbum, admin, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+        albumManager.albumSetAdmin(newAlbum, admin);
 
         // 앨범에 초대된 멤버 권한 부여
         albumCreateRequestDto.getDoInviteNicknameList().forEach(nickname -> {
-            User inviteUser = userRepository.findByNickname(nickname).orElseThrow();
-            albumMemberInvite.invite(newAlbum, inviteUser);
+            User inviteUser = userRepository.findByNickname(nickname)
+                    .orElseThrow(NotInviteUserException::new);
+            albumManager.albumAddMember(newAlbum, inviteUser);
         });
     }
 
     @Transactional
     @Override
     public void editAlbumsTitle(long id, AlbumTitleEditRequestDto albumTitleEditRequestDto) {
-        Album album = albumRepository.findById(id).orElseThrow(NotFoundAlbumException::new);
-        album.setTitle(albumTitleEditRequestDto.getEditTitle());
-        albumRepository.save(album);
+        albumManager.albumEdit(getMemberInfo(id), albumTitleEditRequestDto.getEditTitle());
     }
 
     @Transactional
     @Override
     public void deleteAlbums(long id) {
-        albumRepository.deleteAlbum(id);
+        albumManager.albumDelete(getMemberInfo(id));
+    }
+
+    @Transactional(readOnly = true)
+    private Member getMemberInfo(long id) {
+        // 앨범이 존재하는지 확인
+        albumManager.getAlbumInfo(id);
+
+        User user = userRepository.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        return getAlbumInfo.getAlbumMemberInfo(id, user.getId());
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/advice/UserExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/user/advice/UserExceptionHandler.java
@@ -1,9 +1,6 @@
 package cord.eoeo.momentwo.user.advice;
 
-import cord.eoeo.momentwo.user.advice.exception.DuplicateNicknameException;
-import cord.eoeo.momentwo.user.advice.exception.DuplicateUsernameException;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.advice.exception.PasswordMisMatchException;
+import cord.eoeo.momentwo.user.advice.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -33,5 +30,11 @@ public class UserExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String duplicateNicknameException() {
         return "이미 등록된 별명입니다.";
+    }
+
+    @ExceptionHandler(NotInviteUserException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notInviteUserException() {
+        return "친구 초대 목록에 존재하지 않는 유저가 포함되어 있습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/advice/exception/NotInviteUserException.java
+++ b/src/main/java/cord/eoeo/momentwo/user/advice/exception/NotInviteUserException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.user.advice.exception;
+
+public class NotInviteUserException extends RuntimeException{
+}


### PR DESCRIPTION
### fix
- 앨범 생성 멤버 초대 구간에서 유저 정보가 없을 때 예외처리 누락 추가

### 앨범 패키지 수정

### 앨범 제목 편집
- 관리자만 제목을 편집할 수 있도록 수정
 
#### 앨범 삭제 수정
- 관리자만 앨범을 삭제할 수 있도록 수정

feat. AOP와 커스텀 어노테이션을 통해 앨범 삭제를 진행