### PR TITLE
앨범 삭제 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/advice/AlbumExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/album/advice/AlbumExceptionHandler.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.album.advice;
 
 import cord.eoeo.momentwo.album.advice.exception.NotAlbumAdminException;
+import cord.eoeo.momentwo.album.advice.exception.NotDeleteAlbumException;
 import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -19,5 +20,11 @@ public class AlbumExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String notAlbumAdminException() {
         return "앨범 관리자만 해당 기능을 사용할 수 있습니다.";
+    }
+
+    @ExceptionHandler(NotDeleteAlbumException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String notDeleteAlbumException() {
+        return "멤버가 존재하는 앨범은 삭제할 수 없습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/advice/exception/NotDeleteAlbumException.java
+++ b/src/main/java/cord/eoeo/momentwo/album/advice/exception/NotDeleteAlbumException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.album.advice.exception;
+
+public class NotDeleteAlbumException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.album.application.service;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumCreateRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumTitleEditRequestDto;
+import cord.eoeo.momentwo.album.advice.exception.NotDeleteAlbumException;
 import cord.eoeo.momentwo.album.application.port.in.AlbumUseCase;
 import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
 import cord.eoeo.momentwo.album.domain.Album;
@@ -53,7 +54,12 @@ public class AlbumService implements AlbumUseCase {
     @Transactional
     @Override
     public void deleteAlbums(long id) {
-        albumManager.albumDelete(getMemberInfo(id));
+        Member member = getMemberInfo(id);
+        // 관리자이면서 앨범 속 멤버가 한명 이상인 경우 예외
+        if(getAlbumInfo.isCheckAlbumAdmin(member) && !getAlbumInfo.isCheckAlbumOneMember(id)) {
+            throw new NotDeleteAlbumException();
+        }
+        albumManager.albumDelete(member);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.member.adapter.out;
 
 import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.out.AlbumRepository;
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.advice.exception.NotChangeSameAndUpGradeRulesException;
@@ -116,5 +117,15 @@ public class GetAlbumInfoImpl implements GetAlbumInfo {
     @Transactional(readOnly = true)
     public List<Long> getAlbumIdByAdminUser(User user) {
         return albumMemberRepository.findAlbumIdByAdminUser(user);
+    }
+
+    @Override
+    public boolean isCheckAlbumAdmin(Member member) {
+        return member.getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+    }
+
+    @Override
+    public boolean isCheckAlbumOneMember(long albumId) {
+        return getAlbumMemberList(albumId).size() <= 1;
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetAlbumInfo.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/GetAlbumInfo.java
@@ -30,4 +30,8 @@ public interface GetAlbumInfo {
     boolean isAlbumOut(long albumId, User selfUser);
 
     List<Long> getAlbumIdByAdminUser(User user);
+
+    boolean isCheckAlbumAdmin(Member member);
+
+    boolean isCheckAlbumOneMember(long albumId);
 }


### PR DESCRIPTION
### 앨범 삭제 수정

#### 문제점
#### 1. 앨범 삭제 문제
(변경 전) 기존 앨범 삭제 시 관리자 권한만 있으면 삭제할 수 있었음 
(변경 후) 관리자 권한이 있으면서 앨범에 멤버가 없는 경우 가능

#### 2. 회원 탈퇴 문제
(변경 전) 회원 탈퇴 시 앨범 테이블의 앨범을 삭제하지 않았음 
(변경 후) 회원 탈퇴 시 관리자 권한과 멤버가 없는 경우라면 앨범 테이블 정보 삭제

#### 3. 앨범 나가기 문제
(변경 전) 앨범 나가기 시 관리자가 진행한 경우 앨범 테이블 정보를 삭제 하지 않음 
(변경 후) 앨범 나가기 시 관리자가 진행할 경우 앨범 테이블 정보를 삭제함

Resolve: #53 