### PR TITLE
이미지 맵핑 경로 추가

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
+++ b/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.config.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // /images/ 경로로 들어오는 요청을 로컬 파일 경로로 매핑
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:///C:/Users/qkqkt/Desktop/momentwo/profile/");
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
+++ b/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
@@ -9,8 +9,12 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // /profiles/ 경로로 들어오는 요청을 로컬 파일 경로로 매핑
+        registry.addResourceHandler("/profiles/**")
+                .addResourceLocations("file:///C:/Users/qkqkt/Desktop/momentwo/profiles/");
+
         // /images/ 경로로 들어오는 요청을 로컬 파일 경로로 매핑
-        registry.addResourceHandler("/profile/**")
-                .addResourceLocations("file:///C:/Users/qkqkt/Desktop/momentwo/profile/");
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:///C:/Users/qkqkt/Desktop/momentwo/images/");
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
+++ b/src/main/java/cord/eoeo/momentwo/config/web/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         // /images/ 경로로 들어오는 요청을 로컬 파일 경로로 매핑
-        registry.addResourceHandler("/images/**")
+        registry.addResourceHandler("/profile/**")
                 .addResourceLocations("file:///C:/Users/qkqkt/Desktop/momentwo/profile/");
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/image/path/ImagePath.java
+++ b/src/main/java/cord/eoeo/momentwo/image/path/ImagePath.java
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.image.path;
 
 public enum ImagePath {
-    SERVER_PROFILE_PATH(System.getProperty("user.home") + "\\Desktop\\momentwo\\profile\\"),
-    SERVER_IMAGE_PATH(System.getProperty("user.home") + "\\Desktop\\momentwo\\image\\");
+    SERVER_PROFILE_PATH(System.getProperty("user.home") + "\\Desktop\\momentwo\\profiles\\"),
+    SERVER_IMAGE_PATH(System.getProperty("user.home") + "\\Desktop\\momentwo\\images\\");
 
     private String path;
 


### PR DESCRIPTION
### fix
- 이미지 경로 수정

### 이미지 맵핑 경로 추가
- 클라이언트가 이미지를 요청 시 Http url로 접근할 수 있도록 맵핑 주소를 설정해준다.
- profiles/profiles.png, images/image.png 등으로 구현한다.

Resolve: #60 