### PR TITLE
케이스 변환, 사진 업로드 갯수 제한 추가

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/photo/adapter/out/PhotoRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/adapter/out/PhotoRepositoryImpl.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.photo.adapter.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoJpaRepository;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoRepository;
 import cord.eoeo.momentwo.photo.domain.Photo;
@@ -21,5 +22,10 @@ public class PhotoRepositoryImpl implements PhotoRepository {
     @Override
     public void deleteAllBySubAlbumIdAndPhotoId(long subAlbumId, List<Long> imageIds) {
         photoJpaRepository.deleteAllBySubAlbumIdAndPhotoId(subAlbumId, imageIds);
+    }
+
+    @Override
+    public int getAlbumCount(Album album) {
+        return photoJpaRepository.getAlbumCount(album);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/advice/PhotoExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/advice/PhotoExceptionHandler.java
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.photo.advice;
 
 import cord.eoeo.momentwo.photo.advice.exception.NotDeleteImageException;
 import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
+import cord.eoeo.momentwo.photo.advice.exception.PhotoCapacityFullException;
 import cord.eoeo.momentwo.photo.advice.exception.PhotoUploadFailException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,5 +27,11 @@ public class PhotoExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String notFoundPhotoException() {
         return "사진이 존재하지 않습니다.";
+    }
+
+    @ExceptionHandler(PhotoCapacityFullException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String photoCapacityFullException() {
+        return "앨범이 가득찼습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/advice/exception/PhotoCapacityFullException.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/advice/exception/PhotoCapacityFullException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.photo.advice.exception;
+
+public class PhotoCapacityFullException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.photo.application.port.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.domain.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -11,4 +12,7 @@ public interface PhotoJpaRepository extends JpaRepository<Photo, Long> {
     @Modifying
     @Query("DELETE FROM Photo p WHERE p.subAlbum.id = :subAlbumId AND p.id IN :imageIds")
     void deleteAllBySubAlbumIdAndPhotoId(long subAlbumId, List<Long> imageIds);
+
+    @Query("SELECT COUNT(p) FROM Photo p")
+    int getAlbumCount(Album album);
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoRepository.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.photo.application.port.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.domain.Photo;
 import java.util.List;
 
@@ -7,4 +8,6 @@ public interface PhotoRepository {
     void save(Photo photo);
 
     void deleteAllBySubAlbumIdAndPhotoId(long subAlbumId, List<Long> imageIds);
+
+    int getAlbumCount(Album album);
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/domain/Photo.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/domain/Photo.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.photo.domain;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.AllArgsConstructor;
@@ -41,14 +42,20 @@ public class Photo {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "albumId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Album album;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name = "subAlbumId")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private SubAlbum subAlbum;
 
-    public Photo(String imageName, String format, User user, SubAlbum subAlbum) {
+    public Photo(String imageName, String format, User user, Album album, SubAlbum subAlbum) {
         this.imageName = imageName;
         this.format = format;
         this.user = user;
+        this.album = album;
         this.subAlbum = subAlbum;
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/domain/Photo.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/domain/Photo.java
@@ -36,12 +36,12 @@ public class Photo {
     private String format;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false, name = "user_id")
+    @JoinColumn(nullable = false, name = "userId")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false, name = "subAlbum_id")
+    @JoinColumn(nullable = false, name = "subAlbumId")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private SubAlbum subAlbum;
 

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/domain/SubAlbum.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/domain/SubAlbum.java
@@ -34,7 +34,7 @@ public class SubAlbum {
     }
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(nullable = false, name = "album_id")
+    @JoinColumn(nullable = false, name = "albumId")
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Album album;
 


### PR DESCRIPTION
### 케이스 변환, 사진 업로드 갯수 제한 추가
- 스네이크 케이스로 되어 있는 변수를 카멜 케이스로 수정
- 앨범 당 사진 업로드 갯수 1000장으로 제한 추가

Resolve: #84 