### PR TITLE
앨범 조회 기능 추가 및 쿼리 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoListResponseDto.java
@@ -1,0 +1,23 @@
+package cord.eoeo.momentwo.album.adapter.dto;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumInfoListResponseDto {
+    private List<AlbumInfoResponseDto> albumInfoList;
+
+    public AlbumInfoListResponseDto toDo(List<Album> albums) {
+        return new AlbumInfoListResponseDto(
+                albums.stream().map(album -> new AlbumInfoResponseDto().toDo(album))
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoResponseDto.java
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.album.adapter.dto;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumInfoResponseDto {
+    private long id;
+    private String title;
+    private String subTitle;
+    private String profileImage;
+
+    public AlbumInfoResponseDto toDo(Album album) {
+        return new AlbumInfoResponseDto(
+                album.getId(),
+                album.getTitle(),
+                album.getSubTitle(),
+                album.getProfileFilename()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumController.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumController.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.album.adapter.in;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumCreateRequestDto;
+import cord.eoeo.momentwo.album.adapter.dto.AlbumInfoListResponseDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumTitleEditRequestDto;
 import cord.eoeo.momentwo.album.application.port.in.AlbumUseCase;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,11 @@ public class AlbumController {
     @ResponseStatus(HttpStatus.OK)
     public void deleteAlbums(@PathVariable long id) {
         albumUseCase.deleteAlbums(id);
+    }
+
+    @GetMapping("/albums")
+    @ResponseStatus(HttpStatus.OK)
+    public AlbumInfoListResponseDto getAlbums() {
+        return albumUseCase.getAlbums();
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumUseCase.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.album.application.port.in;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumCreateRequestDto;
+import cord.eoeo.momentwo.album.adapter.dto.AlbumInfoListResponseDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumTitleEditRequestDto;
 
 public interface AlbumUseCase {
@@ -9,4 +10,6 @@ public interface AlbumUseCase {
     void editAlbumsTitle(long id, AlbumTitleEditRequestDto albumTitleEditRequestDto);
 
     void deleteAlbums(long id);
+
+    AlbumInfoListResponseDto getAlbums();
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
@@ -51,7 +51,7 @@ public class AlbumMemberRepositoryImpl implements AlbumMemberRepository {
     }
 
     @Override
-    public List<Member> getAlbumSize(User user) {
+    public int getAlbumSize(User user) {
         return albumMemberJpaRepository.getAlbumSize(user);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/AlbumMemberRepositoryImpl.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.member.adapter.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.advice.exception.NotFoundAccessException;
 import cord.eoeo.momentwo.member.application.port.out.AlbumMemberJpaRepository;
 import cord.eoeo.momentwo.member.application.port.out.AlbumMemberRepository;
@@ -53,5 +54,10 @@ public class AlbumMemberRepositoryImpl implements AlbumMemberRepository {
     @Override
     public int getAlbumSize(User user) {
         return albumMemberJpaRepository.getAlbumSize(user);
+    }
+
+    @Override
+    public List<Album> findAlbumByUser(User user) {
+        return albumMemberJpaRepository.findAlbumByUser(user);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/GetAlbumInfoImpl.java
@@ -133,6 +133,6 @@ public class GetAlbumInfoImpl implements GetAlbumInfo {
     @Override
     @Transactional
     public boolean isCheckAlbumSize(User user) {
-        return albumMemberRepository.getAlbumSize(user).size() > 20;
+        return albumMemberRepository.getAlbumSize(user) >= 20;
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.member.application.port.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.domain.Member;
 import cord.eoeo.momentwo.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -30,4 +31,7 @@ public interface AlbumMemberJpaRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT COUNT(m) FROM Member m WHERE m.user = :user")
     int getAlbumSize(User user);
+
+    @Query("SELECT m.album FROM Member m WHERE m.user = :user")
+    List<Album> findAlbumByUser(User user);
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberJpaRepository.java
@@ -28,6 +28,6 @@ public interface AlbumMemberJpaRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m.album.id FROM Member m WHERE m.user = :user AND m.rules = 'ROLE_ALBUM_ADMIN'")
     List<Long> findAlbumIdByAdminUser(User user);
 
-    @Query("SELECT m FROM Member m WHERE m.user = :user")
-    List<Member> getAlbumSize(User user);
+    @Query("SELECT COUNT(m) FROM Member m WHERE m.user = :user")
+    int getAlbumSize(User user);
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.member.application.port.out;
 
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.domain.Member;
 import cord.eoeo.momentwo.user.domain.User;
 
@@ -21,4 +22,6 @@ public interface AlbumMemberRepository {
     List<Long> findAlbumIdByAdminUser(User user);
 
     int getAlbumSize(User user);
+
+    List<Album> findAlbumByUser(User user);
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/out/AlbumMemberRepository.java
@@ -20,5 +20,5 @@ public interface AlbumMemberRepository {
 
     List<Long> findAlbumIdByAdminUser(User user);
 
-    List<Member> getAlbumSize(User user);
+    int getAlbumSize(User user);
 }


### PR DESCRIPTION
### 앨범 조회 기능 추가 및 쿼리 수정

#### 앨범 조회 기능
- 현재 포함된 앨범을 모두 리턴하며 id, 서브타이틀, 대표이미지 url 등을 포함한다.
#### 쿼리 수정
- 현재 리스트로 갯수를 카운트 하는 구문을 카운트 쿼리로 변환해 적용한다.

Resolve: #82 