### PR TITLE
댓글 패키지 구성

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentCreateRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentCreateRequestDto.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.comment.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentCreateRequestDto {
+    private long albumId;
+    private long photoId;
+    private String comments;
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentDeleteRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentDeleteRequestDto.java
@@ -1,0 +1,13 @@
+package cord.eoeo.momentwo.comment.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentDeleteRequestDto {
+    private long albumId;
+    private long commentId;
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentEditRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentEditRequestDto.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.comment.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentEditRequestDto {
+    private long albumId;
+    private long CommentId;
+    private String editComments;
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentGetRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/in/CommentGetRequestDto.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.comment.adapter.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentGetRequestDto {
+    private long albumId;
+    private long photoId;
+    private long cursorId;
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/out/CommentListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/out/CommentListResponseDto.java
@@ -1,0 +1,24 @@
+package cord.eoeo.momentwo.comment.adapter.dto.out;
+
+import cord.eoeo.momentwo.comment.domain.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentListResponseDto {
+    private List<CommentResponseDto> commentsList;
+
+    public CommentListResponseDto toDo(Page<Comment> comments) {
+        return new CommentListResponseDto(
+                comments.stream().map(comment -> new CommentResponseDto().toDo(comment))
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/out/CommentResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/dto/out/CommentResponseDto.java
@@ -1,0 +1,27 @@
+package cord.eoeo.momentwo.comment.adapter.dto.out;
+
+import cord.eoeo.momentwo.comment.domain.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentResponseDto {
+    private long id;
+    private String nickname;
+    private String comment;
+    private LocalDate date;
+
+    public CommentResponseDto toDo(Comment comment) {
+        return new CommentResponseDto(
+                comment.getId(),
+                comment.getUser().getNickname(),
+                comment.getComments(),
+                comment.getDate()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/in/CommentController.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/in/CommentController.java
@@ -1,0 +1,49 @@
+package cord.eoeo.momentwo.comment.adapter.in;
+
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentCreateRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentDeleteRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentEditRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentGetRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.out.CommentListResponseDto;
+import cord.eoeo.momentwo.comment.application.port.in.CommentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/photo/comments")
+public class CommentController {
+    private final int PAGE_SIZE = 10;
+    private final CommentUseCase commentUseCase;
+
+    @PostMapping("/create")
+    @ResponseStatus(HttpStatus.OK)
+    public void createComment(@RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto) {
+        commentUseCase.createComment(commentCreateRequestDto);
+    }
+
+    @PutMapping("/edit")
+    @ResponseStatus(HttpStatus.OK)
+    public void editComment(@RequestBody @Valid CommentEditRequestDto commentEditRequestDto) {
+        commentUseCase.editComment(commentEditRequestDto);
+    }
+
+    @DeleteMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteComment(@RequestBody @Valid CommentDeleteRequestDto commentDeleteRequestDto) {
+        commentUseCase.deleteComment(commentDeleteRequestDto);
+    }
+
+    @GetMapping()
+    @ResponseStatus(HttpStatus.OK)
+    public CommentListResponseDto getComment(@RequestBody @Valid CommentGetRequestDto commentGetRequestDto,
+                 @PageableDefault(size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return commentUseCase.getComment(commentGetRequestDto, pageable);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentManagerImpl.java
@@ -1,0 +1,68 @@
+package cord.eoeo.momentwo.comment.adapter.out;
+
+import cord.eoeo.momentwo.comment.adapter.dto.out.CommentListResponseDto;
+import cord.eoeo.momentwo.comment.advice.exception.NotCommentAccessException;
+import cord.eoeo.momentwo.comment.application.port.out.CommentManager;
+import cord.eoeo.momentwo.comment.application.port.out.CommentPageRepository;
+import cord.eoeo.momentwo.comment.application.port.out.CommentRepository;
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
+import cord.eoeo.momentwo.photo.application.port.out.PhotoRepository;
+import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
+import cord.eoeo.momentwo.user.application.port.out.UserRepository;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@Configuration
+@RequiredArgsConstructor
+public class CommentManagerImpl implements CommentManager {
+    private final CommentRepository commentRepository;
+    private final GetAuthentication getAuthentication;
+    private final UserRepository userRepository;
+    private final PhotoRepository photoRepository;
+    private final CommentPageRepository commentPageRepository;
+
+    @Override
+    @Transactional
+    public void commentCreate(String comments, long photoId) {
+        User user = userRepository.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        Photo photo = photoRepository.findById(photoId).orElseThrow(NotFoundPhotoException::new);
+
+        Comment comment = new Comment(comments, user, photo);
+        commentRepository.save(comment);
+    }
+
+    @Override
+    @Transactional
+    public void commentEdit(String editComments, long commentId) {
+        User user = userRepository.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        Comment comment = commentRepository.findByIdAndUser(commentId, user)
+                .orElseThrow(NotCommentAccessException::new);
+        comment.setComments(editComments);
+        commentRepository.save(comment);
+    }
+
+    @Override
+    @Transactional
+    public void commentDelete(long commentId) {
+        User user = userRepository.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        commentRepository.findByIdAndUser(commentId, user).orElseThrow(NotCommentAccessException::new);
+        commentRepository.deleteById(commentId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CommentListResponseDto commentGet(long photoId, Pageable pageable, long cursorId) {
+        Photo photo = photoRepository.findById(photoId).orElseThrow(NotFoundPhotoException::new);
+        return new CommentListResponseDto()
+                .toDo(commentPageRepository.getCommentByPhotoPaging(photo, pageable, cursorId));
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentPageRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentPageRepositoryImpl.java
@@ -1,0 +1,41 @@
+package cord.eoeo.momentwo.comment.adapter.out;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import cord.eoeo.momentwo.comment.application.port.out.CommentPageRepository;
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.comment.domain.QComment;
+import cord.eoeo.momentwo.photo.domain.Photo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentPageRepositoryImpl implements CommentPageRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    @Override
+    public Page<Comment> getCommentByPhotoPaging(Photo photo, Pageable pageable, long cursorId) {
+        QComment comment = QComment.comment;
+
+        List<Comment> comments = jpaQueryFactory
+                .select(comment)
+                .from(comment)
+                .where(comment.photo.eq(photo).and(cursor(cursorId, comment)))
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(comments);
+    }
+
+    private BooleanExpression cursor(Long cursorId, QComment comment) {
+        if(cursorId == null) {
+            return null;
+        }
+        return comment.id.gt(cursorId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/CommentRepositoryImpl.java
@@ -1,0 +1,31 @@
+package cord.eoeo.momentwo.comment.adapter.out;
+
+import cord.eoeo.momentwo.comment.application.port.out.CommentJpaRepository;
+import cord.eoeo.momentwo.comment.application.port.out.CommentRepository;
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+    private final CommentJpaRepository commentJpaRepository;
+
+    @Override
+    public void save(Comment comment) {
+        commentJpaRepository.save(comment);
+    }
+
+    @Override
+    public Optional<Comment> findByIdAndUser(long id, User user) {
+        return commentJpaRepository.findByIdAndUser(id, user);
+    }
+
+    @Override
+    public void deleteById(long id) {
+        commentJpaRepository.deleteById(id);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/advice/CommentExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/advice/CommentExceptionHandler.java
@@ -1,0 +1,23 @@
+package cord.eoeo.momentwo.comment.advice;
+
+import cord.eoeo.momentwo.comment.advice.exception.NotCommentAccessException;
+import cord.eoeo.momentwo.comment.advice.exception.NotFoundCommentException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommentExceptionHandler {
+    @ExceptionHandler(NotFoundCommentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notFoundCommentException() {
+        return "존재하지 않는 댓글입니다.";
+    }
+
+    @ExceptionHandler(NotCommentAccessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notCommentAccessException() {
+        return "댓글에 접근할 권한이 없습니다.";
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/advice/exception/NotCommentAccessException.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/advice/exception/NotCommentAccessException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.comment.advice.exception;
+
+public class NotCommentAccessException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/advice/exception/NotFoundCommentException.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/advice/exception/NotFoundCommentException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.comment.advice.exception;
+
+public class NotFoundCommentException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/in/CommentUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/in/CommentUseCase.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.comment.application.port.in;
+
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentCreateRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentDeleteRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentEditRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentGetRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.out.CommentListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentUseCase {
+    void createComment(CommentCreateRequestDto commentCreateRequestDto);
+    void editComment(CommentEditRequestDto commentEditRequestDto);
+    void deleteComment(CommentDeleteRequestDto commentDeleteRequestDto);
+    CommentListResponseDto getComment(CommentGetRequestDto commentGetRequestDto, Pageable pageable);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentJpaRepository.java
@@ -1,0 +1,13 @@
+package cord.eoeo.momentwo.comment.application.port.out;
+
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.user = :user")
+    Optional<Comment> findByIdAndUser(long id, User user);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentManager.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentManager.java
@@ -1,0 +1,11 @@
+package cord.eoeo.momentwo.comment.application.port.out;
+
+import cord.eoeo.momentwo.comment.adapter.dto.out.CommentListResponseDto;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentManager {
+    void commentCreate(String comments, long photoId);
+    void commentEdit(String editComments, long commentId);
+    void commentDelete(long commentId);
+    CommentListResponseDto commentGet(long PhotoId, Pageable pageable, long cursorId);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentPageRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentPageRepository.java
@@ -1,0 +1,10 @@
+package cord.eoeo.momentwo.comment.application.port.out;
+
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.photo.domain.Photo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentPageRepository {
+    Page<Comment> getCommentByPhotoPaging(Photo photo, Pageable pageable, long cursorId);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/CommentRepository.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.comment.application.port.out;
+
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.user.domain.User;
+
+import java.util.Optional;
+
+public interface CommentRepository {
+    void save(Comment comment);
+
+    Optional<Comment> findByIdAndUser(long id, User user);
+
+    void deleteById(long id);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentService.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentService.java
@@ -1,0 +1,53 @@
+package cord.eoeo.momentwo.comment.application.service;
+
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentCreateRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentDeleteRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentEditRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.in.CommentGetRequestDto;
+import cord.eoeo.momentwo.comment.adapter.dto.out.CommentListResponseDto;
+import cord.eoeo.momentwo.comment.application.port.in.CommentUseCase;
+import cord.eoeo.momentwo.comment.application.port.out.CommentManager;
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService implements CommentUseCase {
+    private final CommentManager commentManager;
+
+    @Override
+    @CheckAlbumAccessRules
+    public void createComment(CommentCreateRequestDto commentCreateRequestDto) {
+        commentManager.commentCreate(
+                commentCreateRequestDto.getComments(),
+                commentCreateRequestDto.getPhotoId()
+        );
+    }
+
+    @Override
+    @CheckAlbumAccessRules
+    public void editComment(CommentEditRequestDto commentEditRequestDto) {
+        commentManager.commentEdit(
+                commentEditRequestDto.getEditComments(),
+                commentEditRequestDto.getCommentId()
+        );
+    }
+
+    @Override
+    @CheckAlbumAccessRules
+    public void deleteComment(CommentDeleteRequestDto commentDeleteRequestDto) {
+        commentManager.commentDelete(commentDeleteRequestDto.getCommentId());
+    }
+
+    @Override
+    @CheckAlbumAccessRules
+    public CommentListResponseDto getComment(CommentGetRequestDto commentGetRequestDto, Pageable pageable) {
+        return commentManager.commentGet(
+                commentGetRequestDto.getPhotoId(),
+                pageable,
+                commentGetRequestDto.getCursorId()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/domain/Comment.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/domain/Comment.java
@@ -1,0 +1,50 @@
+package cord.eoeo.momentwo.comment.domain;
+
+import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String comments;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "userId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "photoId")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Photo photo;
+
+    @DateTimeFormat(pattern = "yyyy-mm-dd")
+    private LocalDate date;
+
+    @PrePersist
+    public void init() {
+        this.date = LocalDate.now();
+    }
+
+    public Comment(String comments, User user, Photo photo) {
+        this.comments = comments;
+        this.user = user;
+        this.photo = photo;
+    }
+}


### PR DESCRIPTION
### 댓글 패키지 구성
- 도메인
- 패키지 구조를 구성한다.

### 추가사항
- 댓글 수정, 삭제 시 본인이 작성한 댓글만 가능하도록 구현
- 댓글에 관련된 모든 기능은 앨범에 접근권한이 있어야 가능
- 댓글 조회 시 10개씩 페이징되도록 구현