### PR TITLE
사진 설명 중복 생성 오류, 타인 접근제어 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/description/advice/DescriptionExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/description/advice/DescriptionExceptionHandler.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.description.advice;
 
+import cord.eoeo.momentwo.description.advice.exception.NotCreateDescriptionException;
 import cord.eoeo.momentwo.description.advice.exception.NotFoundDescriptionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,5 +13,11 @@ public class DescriptionExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String notFoundDescriptionException() {
         return "작성 없음";
+    }
+
+    @ExceptionHandler(NotCreateDescriptionException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notCreateDescriptionException() {
+        return "작성된 설명이 있습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/description/advice/exception/NotCreateDescriptionException.java
+++ b/src/main/java/cord/eoeo/momentwo/description/advice/exception/NotCreateDescriptionException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.description.advice.exception;
+
+public class NotCreateDescriptionException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/photo/adapter/out/PhotoRepositoryImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/adapter/out/PhotoRepositoryImpl.java
@@ -4,6 +4,7 @@ import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoJpaRepository;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoRepository;
 import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -33,5 +34,10 @@ public class PhotoRepositoryImpl implements PhotoRepository {
     @Override
     public Optional<Photo> findById(long id) {
         return photoJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Photo> findByIdAndUser(long id, User user) {
+        return photoJpaRepository.findByIdAndUser(id, user);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/advice/PhotoExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/advice/PhotoExceptionHandler.java
@@ -1,9 +1,6 @@
 package cord.eoeo.momentwo.photo.advice;
 
-import cord.eoeo.momentwo.photo.advice.exception.NotDeleteImageException;
-import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
-import cord.eoeo.momentwo.photo.advice.exception.PhotoCapacityFullException;
-import cord.eoeo.momentwo.photo.advice.exception.PhotoUploadFailException;
+import cord.eoeo.momentwo.photo.advice.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -33,5 +30,11 @@ public class PhotoExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public String photoCapacityFullException() {
         return "앨범이 가득찼습니다.";
+    }
+
+    @ExceptionHandler(NotPhotoAccessException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String notPhotoAccessException() {
+        return "사진이 존재하지 않거나 사진에 접근할 권한이 없습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/advice/exception/NotPhotoAccessException.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/advice/exception/NotPhotoAccessException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.photo.advice.exception;
+
+public class NotPhotoAccessException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
@@ -2,11 +2,13 @@ package cord.eoeo.momentwo.photo.application.port.out;
 
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PhotoJpaRepository extends JpaRepository<Photo, Long> {
     @Modifying
@@ -15,4 +17,7 @@ public interface PhotoJpaRepository extends JpaRepository<Photo, Long> {
 
     @Query("SELECT COUNT(p) FROM Photo p")
     int getAlbumCount(Album album);
+
+    @Query("SELECT p FROM Photo p WHERE p.id = :id AND p.user = :user")
+    Optional<Photo> findByIdAndUser(long id, User user);
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoRepository.java
@@ -2,6 +2,8 @@ package cord.eoeo.momentwo.photo.application.port.out;
 
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.user.domain.User;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -13,4 +15,6 @@ public interface PhotoRepository {
     int getAlbumCount(Album album);
 
     Optional<Photo> findById(long id);
+
+    Optional<Photo> findByIdAndUser(long id, User user);
 }


### PR DESCRIPTION
### 사진 설명 중복 생성 오류, 타인 접근제어 수정
- 설명을 중복으로 작성할 수 있는 문제점이 발견됨
- 사진을 업로드한 사람만 설명을 작성할 수 있도록 수정해야 함
- 설명을 수정할 때 업로드한 사람만 수정 가능하도록 수정 해야함