### PR TITLE
사진 좋아요 응답 값 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/LikesStatusSearchRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/LikesStatusSearchRequestDto.java
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LikesStatusSearchRequestDto {
+    private long subAlbumId;
+    private int page;
+    private int size;
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchListResponseDto.java
@@ -1,0 +1,37 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out;
+
+
+import cord.eoeo.momentwo.elasticsearch.domain.LikesDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LikesStatusSearchListResponseDto {
+    private List<LikesStatusSearchResponseDto> likesList;
+    private long page;
+    private long size;
+    private long totalPages;
+    private long totalElements;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public LikesStatusSearchListResponseDto toDo(Page<LikesDocument> likesDocuments) {
+        return new LikesStatusSearchListResponseDto(
+                likesDocuments.stream().map(likesDocument -> new LikesStatusSearchResponseDto().toDo(likesDocument))
+                        .collect(Collectors.toList()),
+                likesDocuments.getNumber(),
+                likesDocuments.getSize(),
+                likesDocuments.getTotalPages(),
+                likesDocuments.getTotalElements(),
+                likesDocuments.hasNext(),
+                likesDocuments.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchResponseDto.java
@@ -1,0 +1,27 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out;
+
+import cord.eoeo.momentwo.elasticsearch.domain.LikesDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LikesStatusSearchResponseDto {
+    private long albumId;
+    private long subAlbumId;
+    private long photoId;
+    private String nickname;
+    private boolean likesStatus;
+
+    public LikesStatusSearchResponseDto toDo(LikesDocument likesDocument) {
+        return new LikesStatusSearchResponseDto(
+                likesDocument.getAlbumId(),
+                likesDocument.getSubAlbumId(),
+                likesDocument.getPhotoId(),
+                likesDocument.getNickname(),
+                true
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/LikesSearchController.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/LikesSearchController.java
@@ -1,7 +1,9 @@
 package cord.eoeo.momentwo.elasticsearch.adpater.in;
 
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesStatusSearchRequestDto;
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesSearchListResponseDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesStatusSearchListResponseDto;
 import cord.eoeo.momentwo.elasticsearch.application.port.in.LikesSearchUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,5 +20,12 @@ public class LikesSearchController {
     @ResponseStatus(HttpStatus.OK)
     public LikesSearchListResponseDto getPhotoLikes(@ModelAttribute @Valid LikesSearchRequestDto likesSearchRequestDto) {
         return likesSearchUseCase.getPhotoLikes(likesSearchRequestDto);
+    }
+
+    @GetMapping("/photo/likes/status/search")
+    @ResponseStatus(HttpStatus.OK)
+    public LikesStatusSearchListResponseDto getPhotoLikesStatus(
+            @ModelAttribute @Valid LikesStatusSearchRequestDto likesStatusSearchRequestDto) {
+        return likesSearchUseCase.getPhotoLikesStatus(likesStatusSearchRequestDto);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/LikesSearchUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/LikesSearchUseCase.java
@@ -1,8 +1,11 @@
 package cord.eoeo.momentwo.elasticsearch.application.port.in;
 
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesStatusSearchRequestDto;
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesSearchListResponseDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesStatusSearchListResponseDto;
 
 public interface LikesSearchUseCase {
     LikesSearchListResponseDto getPhotoLikes(LikesSearchRequestDto likesSearchRequestDto);
+    LikesStatusSearchListResponseDto getPhotoLikesStatus(LikesStatusSearchRequestDto likesStatusSearchRequestDto);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.elasticsearch.application.port.out;
 
 import cord.eoeo.momentwo.elasticsearch.domain.LikesDocument;
+import cord.eoeo.momentwo.photo.domain.Photo;
 import cord.eoeo.momentwo.user.domain.User;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
@@ -8,8 +9,9 @@ import org.springframework.data.domain.Pageable;
 
 @Configuration
 public interface LikesElasticSearchManager {
-    void save(User user, long photoId);
+    void save(User user, Photo photo);
     Page<LikesDocument> getPhotoLikesPaging(long photoId, Pageable pageable);
     void deleteByLikes(long id, String nickname);
     boolean isLikes(User user, long photoId);
+    Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, Pageable pageable);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/LikesSearchService.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/LikesSearchService.java
@@ -1,10 +1,13 @@
 package cord.eoeo.momentwo.elasticsearch.application.service;
 
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.LikesStatusSearchRequestDto;
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesSearchListResponseDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.LikesStatusSearchListResponseDto;
 import cord.eoeo.momentwo.elasticsearch.application.port.in.LikesSearchUseCase;
 import cord.eoeo.momentwo.elasticsearch.application.port.out.LikesElasticSearchManager;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +17,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LikesSearchService implements LikesSearchUseCase {
     private final LikesElasticSearchManager likesElasticSearchManager;
+    private final GetAuthentication getAuthentication;
 
     @Override
     @CheckAlbumAccessRules
@@ -22,5 +26,20 @@ public class LikesSearchService implements LikesSearchUseCase {
 
         return new LikesSearchListResponseDto()
                 .toDo(likesElasticSearchManager.getPhotoLikesPaging(likesSearchRequestDto.getPhotoId(), pageable));
+    }
+
+    @Override
+    @CheckAlbumAccessRules
+    public LikesStatusSearchListResponseDto getPhotoLikesStatus(LikesStatusSearchRequestDto likesStatusSearchRequestDto) {
+        Pageable pageable = PageRequest
+                .of(likesStatusSearchRequestDto.getPage(), likesStatusSearchRequestDto.getSize());
+
+        return new LikesStatusSearchListResponseDto()
+                .toDo(likesElasticSearchManager
+                        .getPhotoLikesStatus(
+                                likesStatusSearchRequestDto.getSubAlbumId(),
+                                getAuthentication.getAuthentication().getName(),
+                                pageable)
+                );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.elasticsearch.domain;
 
+import cord.eoeo.momentwo.photo.domain.Photo;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,9 +25,17 @@ public class LikesDocument {
     @Field(type = FieldType.Keyword)
     private String nickname;
 
-    public LikesDocument(User user, long photoId) {
-        this.id = photoId + "_" + user.getNickname();
-        this.photoId = photoId;
+    @Field(type = FieldType.Keyword)
+    private long albumId;
+
+    @Field(type = FieldType.Keyword)
+    private long subAlbumId;
+
+    public LikesDocument(User user, Photo photo) {
+        this.id = photo.getId() + "_" + user.getNickname();
+        this.photoId = photo.getId();
         this.nickname = user.getNickname();
+        this.albumId = photo.getAlbum().getId();
+        this.subAlbumId = photo.getSubAlbum().getId();
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/like/adapter/out/PhotoLikesManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/like/adapter/out/PhotoLikesManagerImpl.java
@@ -39,13 +39,13 @@ public class PhotoLikesManagerImpl implements PhotoLikesManager {
                         // 값이 존재하는 경우 수행할 작업
                         photoLike.setCount(photoLike.getCount() + 1);
                         photoLikesRepository.save(photoLike);
-                        likesElasticSearchManager.save(user, photoId);
+                        likesElasticSearchManager.save(user, photo);
                     },
                     () -> {
                         // 값이 존재하지 않는 경우 수행할 작업
                         PhotoLike photoLike = new PhotoLike(photo);
                         photoLikesRepository.save(photoLike);
-                        likesElasticSearchManager.save(user, photoId);
+                        likesElasticSearchManager.save(user, photo);
                     });
         }
     }


### PR DESCRIPTION
### 사진 좋아요 응답 값 수정
- 좋아요 누른 사진에 대한 상태 값을 표현할 필요가 있음
  (클라이언트에서 다음 뷰로 넘겨줄 때 좋아요 값을 같이 넘겨주면 좋기 때문)

### 구현
- 자신이 누른 좋아요 사진의 정보를 검색하고 싶다면 client가 검색엔진에 데이터를 요청하고 처리할 수 있도록 구현
- 즉, 데이터베이스에서 50장의 사진을 페이징하는 함수가 있고, 좋아요에 대한 정보만 알 수 있는 검색엔진 함수가 있다.

Resolve: #106 