### PR TITLE
앨범 사진 제한 버그 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/PhotoJpaRepository.java
@@ -15,7 +15,7 @@ public interface PhotoJpaRepository extends JpaRepository<Photo, Long> {
     @Query("DELETE FROM Photo p WHERE p.subAlbum.id = :subAlbumId AND p.id IN :imageIds")
     void deleteAllBySubAlbumIdAndPhotoId(long subAlbumId, List<Long> imageIds);
 
-    @Query("SELECT COUNT(p) FROM Photo p")
+    @Query("SELECT COUNT(p) FROM Photo p WHERE p.album = :album")
     int getAlbumCount(Album album);
 
     @Query("SELECT p FROM Photo p WHERE p.id = :id AND p.user = :user")


### PR DESCRIPTION
### 앨범 사진 제한 버그 수정
- 기존에 구현한 레포 코드에서 앨범에 대한 분류가 빠져 모든 앨범에 대해 1000장의 사진을 제한했다.
- 레포에 앨범에 대한 명시를 하여 앨범당 천장으로 구분할 수 있도록 수정

Resolve: #112 