### PR TITLE
검색엔진과 유저 동기화 작업

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/config/security/SecurityConfig.java
+++ b/src/main/java/cord/eoeo/momentwo/config/security/SecurityConfig.java
@@ -28,7 +28,6 @@ public class SecurityConfig {
     private static final String[] WHITE_LIST = {
             "/signup",
             "/signin",
-            "/signout",
             "/check_email",
             "/check_nickname",
             "/search/username",

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/FriendsElasticSearchManager.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/FriendsElasticSearchManager.java
@@ -8,4 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface FriendsElasticSearchManager {
     void save(long id, String toNickname);
     Page<FriendsDocument> getFriendsPaging(String keyword, User user, Pageable pageable);
+    void deleteById(long id);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
@@ -14,4 +14,5 @@ public interface LikesElasticSearchManager {
     void deleteByLikes(long id, String nickname);
     boolean isLikes(User user, long photoId);
     Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, Pageable pageable);
+    void deleteByWildNickname(String nickname);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/UserElasticSearchManager.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/UserElasticSearchManager.java
@@ -8,4 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface UserElasticSearchManager {
     void save(User user);
     Page<UserDocument> getUsersPaging(String keyword, User user, Pageable pageable);
+    void deleteById(long id);
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/UserStatusService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/UserStatusService.java
@@ -3,6 +3,9 @@ package cord.eoeo.momentwo.user.application.service;
 import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
 import cord.eoeo.momentwo.config.security.jwt.TokenProvider;
 import cord.eoeo.momentwo.config.security.jwt.adapter.out.TokenResponseDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.FriendsElasticSearchManager;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.LikesElasticSearchManager;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.UserElasticSearchManager;
 import cord.eoeo.momentwo.member.advice.exception.AdminAlbumOutException;
 import cord.eoeo.momentwo.member.application.port.out.GetAlbumInfo;
 import cord.eoeo.momentwo.member.domain.Member;
@@ -39,6 +42,9 @@ public class UserStatusService implements UserStatusUseCase {
     private final GetAlbumInfo getAlbumInfo;
     private final AlbumManager albumManager;
     private final UserDetailsService userDetailsService;
+    private final UserElasticSearchManager userElasticSearchManager;
+    private final FriendsElasticSearchManager friendsElasticSearchManager;
+    private final LikesElasticSearchManager likesElasticSearchManager;
 
     @Transactional(readOnly = true)
     @Override
@@ -93,6 +99,9 @@ public class UserStatusService implements UserStatusUseCase {
         });
 
         userRepository.delete(user);
+        userElasticSearchManager.deleteById(user.getId());
+        friendsElasticSearchManager.deleteById(user.getId());
+        likesElasticSearchManager.deleteByWildNickname(user.getNickname());
     }
 
     // 서버에 저장했던 토큰을 갱신하는 방법을 찾아야 함,,,


### PR DESCRIPTION
### 검색엔진과 유저 동기화 작업
- 사용자 및 친구 검색을 이용할 때 회원 탈퇴한 유저가 검색 될 우려가 있음
- 그렇기 때문에 사용자가 회원탈퇴하거나 친구삭제 한 경우 검색엔진과 데이터 베이스를 동기화 할 필요가 있음

- 사용자 검색, 친구 검색, 사진 좋아요 검색 등 회원탈퇴 시 모든 검색엔진 정보도 삭제하도록 구현

### 추후 구현 예정
- 친구 삭제 시 친구 검색에서 삭제하는 코드
- 멤버 제외 시 사진 좋아요 삭제하는 코드

Resolve: #107 