### PR TITLE
PathVariable url 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumDeleteRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumDeleteRequestDto.java
@@ -1,0 +1,12 @@
+package cord.eoeo.momentwo.album.adapter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumDeleteRequestDto {
+    private long albumId;
+}

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumProfileRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumProfileRequestDto.java
@@ -1,0 +1,12 @@
+package cord.eoeo.momentwo.album.adapter.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumProfileRequestDto {
+    private long albumId;
+}

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumTitleEditRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumTitleEditRequestDto.java
@@ -8,5 +8,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AlbumTitleEditRequestDto {
+    private long albumId;
     private String editTitle;
 }

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumController.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumController.java
@@ -10,40 +10,42 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/albums")
 public class AlbumController {
     private final AlbumUseCase albumUseCase;
 
     // 앨범 생성
-    @PostMapping("/albums/create")
+    @PostMapping("/create")
     @ResponseStatus(HttpStatus.OK)
     public void createAlbums(@RequestBody @Valid AlbumCreateRequestDto albumCreateRequestDto) {
         albumUseCase.createAlbums(albumCreateRequestDto);
     }
 
     // 앨범 수정
-    @PutMapping("/albums/edit/{id}")
+    @PutMapping("/edit")
     @ResponseStatus(HttpStatus.OK)
-    public void editAlbumsTitle(@PathVariable long id,
-                                @ModelAttribute @Valid AlbumTitleEditRequestDto albumTitleEditRequestDto) {
-        albumUseCase.editAlbumsTitle(id, albumTitleEditRequestDto);
+    public void editAlbumsTitle(@RequestBody @Valid AlbumTitleEditRequestDto albumTitleEditRequestDto) {
+        albumUseCase.editAlbumsTitle(albumTitleEditRequestDto);
     }
 
     // 앨범 삭제
-    @DeleteMapping("/albums/delete/{id}")
+    @DeleteMapping("/delete")
     @ResponseStatus(HttpStatus.OK)
-    public void deleteAlbums(@PathVariable long id) {
-        albumUseCase.deleteAlbums(id);
+    public void deleteAlbums(@ModelAttribute @Valid AlbumDeleteRequestDto albumDeleteRequestDto) {
+        albumUseCase.deleteAlbums(albumDeleteRequestDto);
     }
 
-    @GetMapping("/albums")
+    // 앨범 전체 목록 조회
+    @GetMapping()
     @ResponseStatus(HttpStatus.OK)
     public AlbumInfoListResponseDto getAlbums() {
         return albumUseCase.getAlbums();
     }
 
-    @GetMapping("/albums/rules")
+    // 앨범 개인 권한 요청
+    @GetMapping("/rules/{albumId}")
     @ResponseStatus(HttpStatus.OK)
-    public AlbumRulesResponseDto getAlbumsRules(@ModelAttribute @Valid AlbumRulesRequestDto albumRulesRequestDto) {
-        return albumUseCase.getAlbumsRules(albumRulesRequestDto);
+    public AlbumRulesResponseDto getAlbumsRules(@PathVariable long albumId) {
+        return albumUseCase.getAlbumsRules(albumId);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumProfileController.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/in/AlbumProfileController.java
@@ -10,34 +10,35 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/albums")
 public class AlbumProfileController {
     private final AlbumProfileUseCase albumProfileUseCase;
 
     // 프로필 업로드 (변경)
-    @PutMapping("/albums/profile/image/upload")
+    @PutMapping("/profile/image/upload")
     @ResponseStatus(HttpStatus.OK)
     public void profileUpload(@ModelAttribute @Valid AlbumProfileUploadRequestDto uploadRequestDto) {
         albumProfileUseCase.profileUpload(uploadRequestDto);
     }
 
     // 프로필 삭제
-    @DeleteMapping("/albums/profile/image/{albumId}")
+    @DeleteMapping("/profile/image")
     @ResponseStatus(HttpStatus.OK)
-    public void profileDelete(@PathVariable long albumId) {
-        albumProfileUseCase.profileDelete(albumId);
+    public void profileDelete(@ModelAttribute @Valid AlbumProfileRequestDto albumProfileRequestDto) {
+        albumProfileUseCase.profileDelete(albumProfileRequestDto);
     }
 
     // 서브 타이틀 수정
-    @PutMapping("/albums/subtitle")
+    @PutMapping("/subtitle")
     @ResponseStatus(HttpStatus.OK)
     public void albumSubTitleEdit(@RequestBody @Valid AlbumSubTitleEditRequestDto subTitleEditRequestDto) {
         albumProfileUseCase.albumSubTitleEdit(subTitleEditRequestDto);
     }
 
     // 서브 타이틀 삭제
-    @DeleteMapping("/albums/subtitle/{albumId}")
+    @DeleteMapping("/subtitle")
     @ResponseStatus(HttpStatus.OK)
-    public void albumSubTitleDelete(@PathVariable long albumId) {
-        albumProfileUseCase.albumSubTitleDelete(albumId);
+    public void albumSubTitleDelete(@ModelAttribute @Valid AlbumProfileRequestDto albumProfileRequestDto) {
+        albumProfileUseCase.albumSubTitleDelete(albumProfileRequestDto);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumProfileUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumProfileUseCase.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.album.application.port.in;
 
+import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileUploadRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumSubTitleEditRequestDto;
 
@@ -8,11 +9,11 @@ public interface AlbumProfileUseCase {
     void profileUpload(AlbumProfileUploadRequestDto uploadRequestDto);
 
     // 프로필 삭제
-    void profileDelete(long albumId);
+    void profileDelete(AlbumProfileRequestDto albumProfileRequestDto);
 
     // 서브 타이틀 수정
     void albumSubTitleEdit(AlbumSubTitleEditRequestDto subTitleEditRequestDto);
 
     // 서브 타이틀 삭제
-    void albumSubTitleDelete(long albumId);
+    void albumSubTitleDelete(AlbumProfileRequestDto albumProfileRequestDto);
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/port/in/AlbumUseCase.java
@@ -5,11 +5,11 @@ import cord.eoeo.momentwo.album.adapter.dto.*;
 public interface AlbumUseCase {
     void createAlbums(AlbumCreateRequestDto albumCreateRequestDto);
 
-    void editAlbumsTitle(long id, AlbumTitleEditRequestDto albumTitleEditRequestDto);
+    void editAlbumsTitle(AlbumTitleEditRequestDto albumTitleEditRequestDto);
 
-    void deleteAlbums(long id);
+    void deleteAlbums(AlbumDeleteRequestDto albumDeleteRequestDto);
 
     AlbumInfoListResponseDto getAlbums();
 
-    AlbumRulesResponseDto getAlbumsRules(AlbumRulesRequestDto albumRulesRequestDto);
+    AlbumRulesResponseDto getAlbumsRules(long albumId);
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumProfileService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumProfileService.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.album.application.service;
 
+import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileUploadRequestDto;
 import cord.eoeo.momentwo.album.adapter.dto.AlbumSubTitleEditRequestDto;
 import cord.eoeo.momentwo.album.application.port.in.AlbumProfileUseCase;
@@ -33,8 +34,8 @@ public class AlbumProfileService implements AlbumProfileUseCase {
 
     @Override
     @Transactional
-    public void profileDelete(long albumId) {
-        albumProfile.profileDelete(getMember(albumId));
+    public void profileDelete(AlbumProfileRequestDto albumProfileRequestDto) {
+        albumProfile.profileDelete(getMember(albumProfileRequestDto.getAlbumId()));
     }
 
     @Override
@@ -48,8 +49,8 @@ public class AlbumProfileService implements AlbumProfileUseCase {
 
     @Override
     @Transactional
-    public void albumSubTitleDelete(long albumId) {
-        albumProfile.albumSubTitleDelete(getMember(albumId));
+    public void albumSubTitleDelete(AlbumProfileRequestDto albumProfileRequestDto) {
+        albumProfile.albumSubTitleDelete(getMember(albumProfileRequestDto.getAlbumId()));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/AlbumService.java
@@ -62,16 +62,17 @@ public class AlbumService implements AlbumUseCase {
 
     @Transactional
     @Override
-    public void editAlbumsTitle(long id, AlbumTitleEditRequestDto albumTitleEditRequestDto) {
-        albumManager.albumEdit(getMemberInfo(id), albumTitleEditRequestDto.getEditTitle());
+    public void editAlbumsTitle(AlbumTitleEditRequestDto albumTitleEditRequestDto) {
+        albumManager.albumEdit(getMemberInfo(albumTitleEditRequestDto.getAlbumId()), albumTitleEditRequestDto.getEditTitle());
     }
 
     @Transactional
     @Override
-    public void deleteAlbums(long id) {
-        Member member = getMemberInfo(id);
+    public void deleteAlbums(AlbumDeleteRequestDto albumDeleteRequestDto) {
+        Member member = getMemberInfo(albumDeleteRequestDto.getAlbumId());
         // 관리자이면서 앨범 속 멤버가 한명 이상인 경우 예외
-        if(getAlbumInfo.isCheckAlbumAdmin(member) && !getAlbumInfo.isCheckAlbumOneMember(id)) {
+        if(getAlbumInfo.isCheckAlbumAdmin(member)
+                && !getAlbumInfo.isCheckAlbumOneMember(albumDeleteRequestDto.getAlbumId())) {
             throw new NotDeleteAlbumException();
         }
         albumManager.albumDelete(member);
@@ -91,8 +92,8 @@ public class AlbumService implements AlbumUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public AlbumRulesResponseDto getAlbumsRules(AlbumRulesRequestDto albumRulesRequestDto) {
-        return new AlbumRulesResponseDto().toDo(getMemberInfo(albumRulesRequestDto.getAlbumId()));
+    public AlbumRulesResponseDto getAlbumsRules(long albumId) {
+        return new AlbumRulesResponseDto().toDo(getMemberInfo(albumId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/in/CommentController.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/in/CommentController.java
@@ -40,10 +40,13 @@ public class CommentController {
         commentUseCase.deleteComment(commentDeleteRequestDto);
     }
 
-    @GetMapping()
+    @GetMapping("/{albumId}/{photoId}")
     @ResponseStatus(HttpStatus.OK)
-    public CommentListResponseDto getComment(@RequestBody @Valid CommentGetRequestDto commentGetRequestDto,
-                 @PageableDefault(size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return commentUseCase.getComment(commentGetRequestDto, pageable);
+    public CommentListResponseDto getComment(
+            @PathVariable long albumId,
+            @PathVariable long photoId,
+            @RequestParam(required = false, defaultValue = "0") long cursor,
+            @PageableDefault(size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return commentUseCase.getComment(albumId, photoId, cursor, pageable);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/in/CommentUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/in/CommentUseCase.java
@@ -11,5 +11,5 @@ public interface CommentUseCase {
     void createComment(CommentCreateRequestDto commentCreateRequestDto);
     void editComment(CommentEditRequestDto commentEditRequestDto);
     void deleteComment(CommentDeleteRequestDto commentDeleteRequestDto);
-    CommentListResponseDto getComment(CommentGetRequestDto commentGetRequestDto, Pageable pageable);
+    CommentListResponseDto getComment(long albumId, long photoId, long cursor, Pageable pageable);
 }

--- a/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentService.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentService.java
@@ -43,11 +43,11 @@ public class CommentService implements CommentUseCase {
 
     @Override
     @CheckAlbumAccessRules
-    public CommentListResponseDto getComment(CommentGetRequestDto commentGetRequestDto, Pageable pageable) {
+    public CommentListResponseDto getComment(long albumId, long photoId, long cursor, Pageable pageable) {
         return commentManager.commentGet(
-                commentGetRequestDto.getPhotoId(),
+                photoId,
                 pageable,
-                commentGetRequestDto.getCursorId()
+                cursor
         );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/description/adapter/in/DescriptionController.java
+++ b/src/main/java/cord/eoeo/momentwo/description/adapter/in/DescriptionController.java
@@ -35,9 +35,12 @@ public class DescriptionController {
         descriptionUseCase.deleteDescription(descriptionRequestDto);
     }
 
-    @GetMapping()
+    @GetMapping("/{albumId}/{photoId}")
     @ResponseStatus(HttpStatus.OK)
-    public DescriptionResponseDto getDescription(@RequestBody @Valid DescriptionRequestDto descriptionRequestDto) {
-        return descriptionUseCase.getDescription(descriptionRequestDto);
+    public DescriptionResponseDto getDescription(
+            @PathVariable long albumId,
+            @PathVariable long photoId
+    ) {
+        return descriptionUseCase.getDescription(albumId, photoId);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/description/adapter/out/DescriptionManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/description/adapter/out/DescriptionManagerImpl.java
@@ -71,8 +71,8 @@ public class DescriptionManagerImpl implements DescriptionManager {
 
     @Override
     @Transactional(readOnly = true)
-    public DescriptionResponseDto getDescription(DescriptionRequestDto descriptionRequestDto) {
-        Photo photo = getPhoto(descriptionRequestDto.getPhotoId());
+    public DescriptionResponseDto getDescription(long photoId) {
+        Photo photo = photoRepository.findById(photoId).orElseThrow(NotFoundPhotoException::new);
 
         Description description = descriptionRepository.findByPhoto(photo)
                 .orElseThrow(NotFoundDescriptionException::new);

--- a/src/main/java/cord/eoeo/momentwo/description/application/port/in/DescriptionUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/description/application/port/in/DescriptionUseCase.java
@@ -9,5 +9,5 @@ public interface DescriptionUseCase {
     void createDescription(DescriptionCreateRequestDto descriptionCreateRequestDto);
     void editDescription(DescriptionEditRequestDto descriptionEditRequestDto);
     void deleteDescription(DescriptionRequestDto descriptionRequestDto);
-    DescriptionResponseDto getDescription(DescriptionRequestDto descriptionRequestDto);
+    DescriptionResponseDto getDescription(long albumId, long photoId);
 }

--- a/src/main/java/cord/eoeo/momentwo/description/application/port/out/DescriptionManager.java
+++ b/src/main/java/cord/eoeo/momentwo/description/application/port/out/DescriptionManager.java
@@ -9,5 +9,5 @@ public interface DescriptionManager {
     void createDescription(DescriptionCreateRequestDto descriptionCreateRequestDto);
     void editDescription(DescriptionEditRequestDto descriptionEditRequestDto);
     void deleteDescription(DescriptionRequestDto descriptionRequestDto);
-    DescriptionResponseDto getDescription(DescriptionRequestDto descriptionRequestDto);
+    DescriptionResponseDto getDescription(long photoId);
 }

--- a/src/main/java/cord/eoeo/momentwo/description/application/service/DescriptionService.java
+++ b/src/main/java/cord/eoeo/momentwo/description/application/service/DescriptionService.java
@@ -35,7 +35,7 @@ public class DescriptionService implements DescriptionUseCase {
 
     @Override
     @CheckAlbumAccessRules
-    public DescriptionResponseDto getDescription(DescriptionRequestDto descriptionRequestDto) {
-        return descriptionManager.getDescription(descriptionRequestDto);
+    public DescriptionResponseDto getDescription(long albumId, long photoId) {
+        return descriptionManager.getDescription(photoId);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/like/adapter/in/PhotoLikeController.java
+++ b/src/main/java/cord/eoeo/momentwo/like/adapter/in/PhotoLikeController.java
@@ -27,9 +27,12 @@ public class PhotoLikeController {
         photoLikeUseCase.undoLikes(photoLikesRequestDto);
     }
 
-    @GetMapping()
+    @GetMapping("/{albumId}/{photoId}")
     @ResponseStatus(HttpStatus.OK)
-    public PhotoLikesResponseDto getLikes(@RequestBody @Valid PhotoLikesRequestDto photoLikesRequestDto) {
-        return photoLikeUseCase.getLikes(photoLikesRequestDto);
+    public PhotoLikesResponseDto getLikes(
+            @PathVariable long albumId,
+            @PathVariable long photoId
+    ) {
+        return photoLikeUseCase.getLikes(albumId, photoId);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/like/application/port/in/PhotoLikeUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/like/application/port/in/PhotoLikeUseCase.java
@@ -6,5 +6,5 @@ import cord.eoeo.momentwo.like.adapter.dto.out.PhotoLikesResponseDto;
 public interface PhotoLikeUseCase {
     void doLikes(PhotoLikesRequestDto photoLikesRequestDto);
     void undoLikes(PhotoLikesRequestDto photoLikesRequestDto);
-    PhotoLikesResponseDto getLikes(PhotoLikesRequestDto photoLikesRequestDto);
+    PhotoLikesResponseDto getLikes(long albumId, long photoId);
 }

--- a/src/main/java/cord/eoeo/momentwo/like/application/service/PhotoLikeService.java
+++ b/src/main/java/cord/eoeo/momentwo/like/application/service/PhotoLikeService.java
@@ -27,8 +27,8 @@ public class PhotoLikeService implements PhotoLikeUseCase {
 
     @Override
     @CheckAlbumAccessRules
-    public PhotoLikesResponseDto getLikes(PhotoLikesRequestDto photoLikesRequestDto) {
+    public PhotoLikesResponseDto getLikes(long albumId, long photoId) {
         return new PhotoLikesResponseDto()
-                .toDo(photoLikesManager.getLikes(photoLikesRequestDto.getPhotoId()));
+                .toDo(photoLikesManager.getLikes(photoId));
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/AlbumMemberController.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/AlbumMemberController.java
@@ -1,9 +1,6 @@
 package cord.eoeo.momentwo.member.adapter.in;
 
-import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.*;
 import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
 import cord.eoeo.momentwo.member.application.port.in.AlbumMemberUseCase;
 import lombok.RequiredArgsConstructor;
@@ -14,50 +11,49 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/members")
 public class AlbumMemberController {
     private final AlbumMemberUseCase albumMemberUseCase;
 
     // 멤버 초대
-    @PostMapping("/{albumId}/members/invite")
+    @PostMapping("/invite")
     @ResponseStatus(HttpStatus.OK)
-    public void inviteMembers(@PathVariable long albumId,
-                             @RequestBody @Valid InviteMembersRequestDto inviteMembersRequestDto) {
-        albumMemberUseCase.inviteMembers(albumId, inviteMembersRequestDto);
+    public void inviteMembers(@RequestBody @Valid InviteMembersRequestDto inviteMembersRequestDto) {
+        albumMemberUseCase.inviteMembers(inviteMembersRequestDto);
     }
 
     // 멤버 조회
-    @GetMapping("/{albumId}/members")
+    @GetMapping("/{albumId}")
     @ResponseStatus(HttpStatus.OK)
     public AlbumMemberResponseDto getMembers(@PathVariable long albumId) {
         return albumMemberUseCase.getMembers(albumId);
     }
 
     // 멤버 추방
-    @DeleteMapping("/{albumId}/members/kick")
+    @DeleteMapping("/kick")
     @ResponseStatus(HttpStatus.OK)
-    public void kickMembers(@PathVariable long albumId,
-                           @RequestBody @Valid KickMembersRequestDto kickMembersRequestDto) {
-        albumMemberUseCase.kickMembers(albumId, kickMembersRequestDto);
+    public void kickMembers(@RequestBody @Valid KickMembersRequestDto kickMembersRequestDto) {
+        albumMemberUseCase.kickMembers(kickMembersRequestDto);
     }
 
     // 멤버 권한 변경 (앨범 수정 권한)
-    @PutMapping("/{albumId}/members/permission")
+    @PutMapping("/permission")
     @ResponseStatus(HttpStatus.OK)
-    public void editMembersGrade(@PathVariable long albumId,
-                                                    @RequestBody @Valid EditGradeListRequestDto editGradeListRequestDto) {
-        albumMemberUseCase.editMembersGrade(albumId, editGradeListRequestDto);
+    public void editMembersGrade(@RequestBody @Valid EditGradeListRequestDto editGradeListRequestDto) {
+        albumMemberUseCase.editMembersGrade(editGradeListRequestDto);
     }
 
     // 관리자 권한 넘겨주기
-    @PutMapping("/{albumId}/members/assign/admin")
-    public void assignAdmin(@PathVariable long albumId,
-                            @ModelAttribute @Valid AssignAdminRequestDto assignAdminRequestDto) {
-        albumMemberUseCase.assignAdmin(albumId, assignAdminRequestDto);
+    @PutMapping("/assign/admin")
+    @ResponseStatus(HttpStatus.OK)
+    public void assignAdmin(@RequestBody @Valid AssignAdminRequestDto assignAdminRequestDto) {
+        albumMemberUseCase.assignAdmin(assignAdminRequestDto);
     }
 
     // 멤버 나가기 (개인)
-    @DeleteMapping("/{albumId}/members/out")
-    public void outAlbum(@PathVariable long albumId) {
-        albumMemberUseCase.outAlbum(albumId);
+    @DeleteMapping("/out")
+    @ResponseStatus(HttpStatus.OK)
+    public void outAlbum(@ModelAttribute @Valid MemberOutRequestDto memberOutRequestDto) {
+        albumMemberUseCase.outAlbum(memberOutRequestDto);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/AssignAdminRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/AssignAdminRequestDto.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AssignAdminRequestDto {
+    private long albumId;
     @NotBlank(message = "별명을 입력해주세요.")
     private String nickname;
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/EditGradeListRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/EditGradeListRequestDto.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 @AllArgsConstructor
 @NoArgsConstructor
 public class EditGradeListRequestDto {
+    private long albumId;
     @NotEmpty(message = "권한 변경을 위한 입력이 올바르지 않습니다.")
     private HashMap<String, String> editMemberList;
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/InviteMembersRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/InviteMembersRequestDto.java
@@ -11,6 +11,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class InviteMembersRequestDto {
+    private long albumId;
     @NotEmpty(message = "초대할 유저 닉네임을 하나이상 입력해주세요.")
     private List<String> inviteNicknames;
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/KickMembersRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/KickMembersRequestDto.java
@@ -10,5 +10,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class KickMembersRequestDto {
+    private long albumId;
     private List<String> kickMemberList;
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/MemberOutRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/dto/MemberOutRequestDto.java
@@ -1,0 +1,12 @@
+package cord.eoeo.momentwo.member.adapter.in.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberOutRequestDto {
+    private long albumId;
+}

--- a/src/main/java/cord/eoeo/momentwo/member/application/port/in/AlbumMemberUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/port/in/AlbumMemberUseCase.java
@@ -1,26 +1,23 @@
 package cord.eoeo.momentwo.member.application.port.in;
 
-import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.*;
 import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
 
 public interface AlbumMemberUseCase {
-    void inviteMembers(long albumId, InviteMembersRequestDto inviteMembersRequestDto);
+    void inviteMembers(InviteMembersRequestDto inviteMembersRequestDto);
 
     // 멤버 조회
     AlbumMemberResponseDto getMembers(long albumId);
 
     // 멤버 추방
-    void kickMembers(long albumId, KickMembersRequestDto kickMembersRequestDto);
+    void kickMembers(KickMembersRequestDto kickMembersRequestDto);
 
     // 멤버 권한 변경 (앨범 수정 권한)
-    void editMembersGrade(long albumId, EditGradeListRequestDto editGradeListRequestDto);
+    void editMembersGrade(EditGradeListRequestDto editGradeListRequestDto);
 
     // 관리자 권한 넘기기
-    void assignAdmin(long albumId, AssignAdminRequestDto assignAdminRequestDto);
+    void assignAdmin(AssignAdminRequestDto assignAdminRequestDto);
 
     // 멤버 나가기 (개인)
-    void outAlbum(long albumId);
+    void outAlbum(MemberOutRequestDto memberOutRequestDto);
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
@@ -2,10 +2,7 @@ package cord.eoeo.momentwo.member.application.service;
 
 import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
 import cord.eoeo.momentwo.album.domain.Album;
-import cord.eoeo.momentwo.member.adapter.in.dto.AssignAdminRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.EditGradeListRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.InviteMembersRequestDto;
-import cord.eoeo.momentwo.member.adapter.in.dto.KickMembersRequestDto;
+import cord.eoeo.momentwo.member.adapter.in.dto.*;
 import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
 import cord.eoeo.momentwo.member.advice.exception.*;
 import cord.eoeo.momentwo.member.application.port.in.AlbumMemberUseCase;
@@ -36,11 +33,11 @@ public class AlbumMemberService implements AlbumMemberUseCase {
 
     @Override
     @Transactional
-    public void inviteMembers(long albumId, InviteMembersRequestDto inviteMembersRequestDto) {
-        Album album = getAlbumInfo.getAlbum(albumId).join();
+    public void inviteMembers(InviteMembersRequestDto inviteMembersRequestDto) {
+        Album album = getAlbumInfo.getAlbum(inviteMembersRequestDto.getAlbumId()).join();
 
         // 이미 앨범에 포함된 멤버
-        List<String> existMember = getAlbumInfo.getAlbumMemberList(albumId);
+        List<String> existMember = getAlbumInfo.getAlbumMemberList(inviteMembersRequestDto.getAlbumId());
 
         List<User> inviteList = new ArrayList<>();
 
@@ -71,9 +68,9 @@ public class AlbumMemberService implements AlbumMemberUseCase {
 
     @Override
     @Transactional
-    public void kickMembers(long albumId, KickMembersRequestDto kickMembersRequestDto) {
+    public void kickMembers(KickMembersRequestDto kickMembersRequestDto) {
         User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
-        getAlbumInfo.checkAuthorityAdmin(albumId, owner.getId());
+        getAlbumInfo.checkAuthorityAdmin(kickMembersRequestDto.getAlbumId(), owner.getId());
 
         // 자신 스스로 추방하려 할 경우
         if(kickMembersRequestDto.getKickMemberList().contains(owner.getNickname())) {
@@ -85,17 +82,17 @@ public class AlbumMemberService implements AlbumMemberUseCase {
             User kickedUser = getMemberInfo.getUserInfoByNickname(nickname).join();
 
             // 본인보다 낮은 권한만 추방 가능
-            getAlbumInfo.doKickMember(albumId, owner, kickedUser);
+            getAlbumInfo.doKickMember(kickMembersRequestDto.getAlbumId(), owner, kickedUser);
         });
 
     }
 
     @Override
     @Transactional
-    public void editMembersGrade(long albumId, EditGradeListRequestDto editGradeListRequestDto) {
+    public void editMembersGrade(EditGradeListRequestDto editGradeListRequestDto) {
         // 권한 변경자의 등급을 확인한다.
         User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
-        getAlbumInfo.checkAuthorityAdmin(albumId, owner.getId());
+        getAlbumInfo.checkAuthorityAdmin(editGradeListRequestDto.getAlbumId(), owner.getId());
 
         // 호스트가 자신의 권한을 변경하려 할 경우
         if(editGradeListRequestDto.getEditMemberList().containsKey(owner.getNickname())) {
@@ -106,48 +103,50 @@ public class AlbumMemberService implements AlbumMemberUseCase {
         // 권한을 변경시킨다.
         editGradeListRequestDto.getEditMemberList().forEach((nickname, rules) -> {
             User target = getMemberInfo.getUserInfoByNickname(nickname).join();
-            getAlbumInfo.changeRules(albumId, owner, target, rules);
+            getAlbumInfo.changeRules(editGradeListRequestDto.getAlbumId(), owner, target, rules);
         });
     }
 
     @Override
     @Transactional
-    public void assignAdmin(long albumId, AssignAdminRequestDto assignAdminRequestDto) {
+    public void assignAdmin(AssignAdminRequestDto assignAdminRequestDto) {
         User owner = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
 
         // 관리자가 아닐경우
-        if(!getAlbumInfo.getAlbumMemberInfo(albumId,
+        if(!getAlbumInfo.getAlbumMemberInfo(assignAdminRequestDto.getAlbumId(),
                 owner.getId()).getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN)) {
             throw new NotChangeAdminException();
         }
         User changeUser = getMemberInfo.getUserInfoByNickname(assignAdminRequestDto.getNickname()).join();
         // 관리자 -> 일반 멤버
-        getAlbumInfo.assignAdmin(albumId, owner, MemberAlbumGrade.ROLE_ALBUM_COMMON_MEMBER);
+        getAlbumInfo.assignAdmin(assignAdminRequestDto.getAlbumId(), owner, MemberAlbumGrade.ROLE_ALBUM_COMMON_MEMBER);
         // 일반 멤버 -> 관리자
-        getAlbumInfo.assignAdmin(albumId, changeUser, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
+        getAlbumInfo.assignAdmin(assignAdminRequestDto.getAlbumId(), changeUser, MemberAlbumGrade.ROLE_ALBUM_ADMIN);
     }
 
     @Override
     @Transactional
-    public void outAlbum(long albumId) {
+    public void outAlbum(MemberOutRequestDto memberOutRequestDto) {
         User selfUser = getMemberInfo.getUserInfoByNickname(getAuthentication.getAuthentication().getName()).join();
-        Member member = getAlbumInfo.getAlbumMemberInfo(albumId, selfUser.getId());
+        Member member = getAlbumInfo.getAlbumMemberInfo(memberOutRequestDto.getAlbumId(), selfUser.getId());
 
         // 앨범 관리자가 나갈 경우 멤버가 존재한다면 나갈 수 없음
         // 하지만 멤버가 없을 경우 나갈 수 있음
-        if(getAlbumInfo.isCheckAlbumAdmin(member) && !getAlbumInfo.isCheckAlbumOneMember(albumId)) {
+        if(getAlbumInfo.isCheckAlbumAdmin(member)
+                && !getAlbumInfo.isCheckAlbumOneMember(memberOutRequestDto.getAlbumId())) {
             throw new AdminAlbumOutException();
         }
 
         // 본인이 앨범에 속해있는지 확인한다.
         // 삭제 된 행이 있으면 true, 없으면 false 반환
-        if(!getAlbumInfo.isAlbumOut(albumId, selfUser)) {
+        if(!getAlbumInfo.isAlbumOut(memberOutRequestDto.getAlbumId(), selfUser)) {
             throw new MemberNotInAlbumException();
         }
 
         // 관리자만 있는 앨범에서 관리자가 나갈 경우
         // 앨범도 같이 삭제 되어야 한다.
-        if(getAlbumInfo.isCheckAlbumAdmin(member) && getAlbumInfo.isCheckAlbumOneMember(albumId)) {
+        if(getAlbumInfo.isCheckAlbumAdmin(member)
+                && getAlbumInfo.isCheckAlbumOneMember(memberOutRequestDto.getAlbumId())) {
             albumManager.albumDelete(member);
         }
     }

--- a/src/main/java/cord/eoeo/momentwo/photo/adapter/in/PhotoController.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/adapter/in/PhotoController.java
@@ -36,10 +36,13 @@ public class PhotoController {
     }
 
     // 조회 (이미지 보기)
-    @GetMapping("/view")
+    @GetMapping("/view/{albumId}/{subAlbumId}")
     @ResponseStatus(HttpStatus.OK)
-    public ImageViewListResponseDto photoView(@RequestBody @Valid PhotoViewRequestDto photoViewRequestDto,
-                  @PageableDefault(size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
-        return photoUseCase.photoView(photoViewRequestDto, pageable);
+    public ImageViewListResponseDto photoView(
+            @PathVariable long albumId,
+            @PathVariable long subAlbumId,
+            @RequestParam(required = false, defaultValue = "0") long cursor,
+            @PageableDefault(size = PAGE_SIZE, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return photoUseCase.photoView(albumId, subAlbumId, cursor, pageable);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/in/PhotoUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/in/PhotoUseCase.java
@@ -9,5 +9,5 @@ import org.springframework.data.domain.Pageable;
 public interface PhotoUseCase {
     void photoUpload(PhotoUploadRequestDto photoUploadRequestDto);
     void photoDelete(PhotoDeleteRequestDto photoDeleteRequestDto);
-    ImageViewListResponseDto photoView(PhotoViewRequestDto photoViewRequestDto, Pageable pageable);
+    ImageViewListResponseDto photoView(long albumId, long subAlbumId, long cursor, Pageable pageable);
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
@@ -103,12 +103,12 @@ public class PhotoService implements PhotoUseCase {
     @Override
     @Transactional(readOnly = true)
     @CheckAlbumAccessRules
-    public ImageViewListResponseDto photoView(PhotoViewRequestDto photoViewRequestDto, Pageable pageable) {
+    public ImageViewListResponseDto photoView(long albumId, long subAlbumId, long cursor, Pageable pageable) {
         Page<Photo> photoList = photoPageRepository
                 .findQPhotoBySubAlbumIdCustomPaging(
-                        photoViewRequestDto.getSubAlbumId(),
+                        subAlbumId,
                         pageable,
-                        photoViewRequestDto.getCursor()
+                        cursor
                 );
         if(photoList.isEmpty()) {
             throw new NotFoundPhotoException();

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/in/SubAlbumController.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/in/SubAlbumController.java
@@ -13,33 +13,33 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/album")
+@RequestMapping("/album/sub")
 public class SubAlbumController {
     private final SubAlbumUseCase subAlbumUseCase;
 
     // 서브앨범 생성
-    @PostMapping("/sub/create")
+    @PostMapping("/create")
     @ResponseStatus(HttpStatus.OK)
     public void createSubAlbum(@RequestBody @Valid SubAlbumCreateRequestDto subAlbumCreateRequestDto) {
         subAlbumUseCase.createSubAlbum(subAlbumCreateRequestDto);
     }
 
     // 서브앨범 조회
-    @GetMapping("/sub/{albumId}")
+    @GetMapping("/{albumId}")
     @ResponseStatus(HttpStatus.OK)
     public SubAlbumListResponseDto getSubAlbums(@PathVariable long albumId) {
         return subAlbumUseCase.getSubAlbums(albumId);
     }
 
     // 서브앨범 수정
-    @PutMapping("/sub/edit")
+    @PutMapping("/edit")
     @ResponseStatus(HttpStatus.OK)
     public void editSubAlbumTitle(@RequestBody @Valid SubAlbumEditTitleRequestDto subAlbumEditTitleRequestDto) {
         subAlbumUseCase.editSubAlbumTitle(subAlbumEditTitleRequestDto);
     }
 
     // 서브앨범 삭제
-    @DeleteMapping("/sub/delete")
+    @DeleteMapping("/delete")
     @ResponseStatus(HttpStatus.OK)
     public void deleteSubAlbums(@RequestBody @Valid SubAlbumDeleteRequestDto subAlbumDeleteRequestDto) {
         subAlbumUseCase.deleteSubAlbums(subAlbumDeleteRequestDto);


### PR DESCRIPTION
### fix
- 사진 설명 조회 함수에서 업로드한 유저만 조회되던 현상을 수정

### PathVariable url 수정
- 일관성 있는 url를 위해 PathVariable 대신 ModelAttribute를 사용하도록 변경한다.

- 수정 구간 album, subAlbum, member, photo 패키지

- 기존에 GET 매핑에서 RequestBody가 있는 구간은 전부 PathVariable or RequestParm으로 대체
- HTTP 규약에 어긋나기 때문 (단, RESTful은 지켜가면서)

Resovle: #117 