### PR TITLE
프리사인드 적용 후 서브앨범 조회 DTO 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/image/adapter/dto/ImageViewListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/image/adapter/dto/ImageViewListResponseDto.java
@@ -1,16 +1,13 @@
 package cord.eoeo.momentwo.image.adapter.dto;
 
-import com.mysema.commons.lang.Pair;
 import cord.eoeo.momentwo.photo.domain.Photo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
-import java.net.URL;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Data
 @AllArgsConstructor
@@ -24,12 +21,9 @@ public class ImageViewListResponseDto {
     private boolean hasNext;
     private boolean hasPrevious;
 
-    public ImageViewListResponseDto toDo(Page<Photo> photos, List<URL> imagesUrl) {
+    public ImageViewListResponseDto toDo(Page<Photo> photos) {
         return new ImageViewListResponseDto(
-                IntStream.range(0, photos.getSize())
-                        .mapToObj(i -> Pair.of(photos.get().collect(Collectors.toList()).get(i), imagesUrl.get(i)))  // Pair로 묶기
-                        .map(pair -> new ImageViewResponseDto().toDo(pair.getFirst(), pair.getSecond().toString()))  // 두 개의 값을 넘김
-                        .collect(Collectors.toList()),
+                photos.stream().map(photo -> new ImageViewResponseDto().toDo(photo)).collect(Collectors.toList()),
                 photos.getNumber(),
                 photos.getSize(),
                 photos.getTotalPages(),

--- a/src/main/java/cord/eoeo/momentwo/image/adapter/dto/ImageViewResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/image/adapter/dto/ImageViewResponseDto.java
@@ -12,7 +12,10 @@ public class ImageViewResponseDto {
     private long id;
     private String imageUrl;
 
-    public ImageViewResponseDto toDo(Photo photo, String imageUrl) {
-        return new ImageViewResponseDto(photo.getId(), imageUrl);
+    public ImageViewResponseDto toDo(Photo photo) {
+        return new ImageViewResponseDto(
+                photo.getId(),
+                photo.getImageName()
+        );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
@@ -28,10 +28,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class PhotoService implements PhotoUseCase {
@@ -102,12 +98,6 @@ public class PhotoService implements PhotoUseCase {
             throw new NotFoundPhotoException();
         }
 
-        List<URL> imagesUrl = new ArrayList<>();
-
-        photoList.forEach(photo -> {
-            imagesUrl.add(imageManager.imageFileSearch(s3Manager.getImagePath() + photo.getImageName()).join());
-        });
-
-        return new ImageViewListResponseDto().toDo(photoList, imagesUrl);
+        return new ImageViewListResponseDto().toDo(photoList);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/dto/SubAlbumListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/dto/SubAlbumListResponseDto.java
@@ -4,7 +4,6 @@ import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,11 +14,10 @@ import java.util.stream.Collectors;
 public class SubAlbumListResponseDto {
     private List<SubAlbumResponseDto> subAlbumList;
 
-    public SubAlbumListResponseDto toDo(
-            List<SubAlbum> subAlbums, S3Client s3Client, String bucketName, String imagePath) {
+    public SubAlbumListResponseDto toDo(List<SubAlbum> subAlbums) {
         return new SubAlbumListResponseDto(
                 subAlbums.stream()
-                        .map(subAlbum -> new SubAlbumResponseDto().toDo(subAlbum, s3Client, bucketName, imagePath))
+                        .map(subAlbum -> new SubAlbumResponseDto().toDo(subAlbum))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/dto/SubAlbumResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/dto/SubAlbumResponseDto.java
@@ -5,7 +5,6 @@ import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,14 +17,12 @@ public class SubAlbumResponseDto {
     private String subAlbumTitle;
     private List<ImageViewResponseDto> subTitleImageList;
 
-    public SubAlbumResponseDto toDo(SubAlbum subAlbum, S3Client s3Client, String buckName, String imagePath) {
+    public SubAlbumResponseDto toDo(SubAlbum subAlbum) {
         return new SubAlbumResponseDto(
                 subAlbum.getId(),
                 subAlbum.getSubAlbumTitle(),
                 subAlbum.getPhotos().stream()
-                        .map(photo -> new ImageViewResponseDto()
-                                .toDo(photo, s3Client.utilities().getUrl(b ->
-                                        b.bucket(buckName).key(imagePath + photo.getImageName())).toString()))
+                        .map(photo -> new ImageViewResponseDto().toDo(photo))
                         .limit(4)
                         .collect(Collectors.toList())
         );

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/out/SubAlbumManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/adapter/out/SubAlbumManagerImpl.java
@@ -6,10 +6,8 @@ import cord.eoeo.momentwo.subAlbum.application.port.out.SubAlbumManager;
 import cord.eoeo.momentwo.subAlbum.application.port.out.SubAlbumRepository;
 import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 
@@ -17,13 +15,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SubAlbumManagerImpl implements SubAlbumManager {
     private final SubAlbumRepository subAlbumRepository;
-    private final S3Client s3Client;
-
-    @Value("${cloud.aws.s3.images-path}")
-    private String imagesPath;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucketName;
 
     @Override
     @Transactional(readOnly = true)
@@ -35,7 +26,7 @@ public class SubAlbumManagerImpl implements SubAlbumManager {
     @Transactional(readOnly = true)
     public SubAlbumListResponseDto getSubAlbumList(long albumId) {
         List<SubAlbum> subAlbumList = subAlbumRepository.getSubAlbumListByAlbumId(albumId);
-        return new SubAlbumListResponseDto().toDo(subAlbumList, s3Client, bucketName, imagesPath);
+        return new SubAlbumListResponseDto().toDo(subAlbumList);
     }
 
     @Override


### PR DESCRIPTION
### 프리사인드 적용 후 서브앨범 조회 DTO 수정
- 프리사인드를 적용하여 기존에 DB에 저장된 이름정보로 URL를 만들 필요 없이 프리사인드 응답 값을 저장하는 구조로 변경하여
DTO 구조를 변경한다

Resolve: #176 