### PR TITLE
검색엔진 좋아요 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/LikesStatusSearchRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/LikesStatusSearchRequestDto.java
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikesStatusSearchRequestDto {
     private long subAlbumId;
-    private int page;
-    private int size;
+    private long minPid;
+    private long maxPid;
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesSearchResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesSearchResponseDto.java
@@ -10,8 +10,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikesSearchResponseDto {
     private String nickname;
+    private String userProfileImage;
 
     public LikesSearchResponseDto toDo(LikesDocument likesDocument) {
-        return new LikesSearchResponseDto(likesDocument.getNickname());
+        return new LikesSearchResponseDto(
+                likesDocument.getNickname(),
+                likesDocument.getUserProfileImage()
+        );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/LikesStatusSearchListResponseDto.java
@@ -15,23 +15,11 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class LikesStatusSearchListResponseDto {
     private List<LikesStatusSearchResponseDto> likesList;
-    private long page;
-    private long size;
-    private long totalPages;
-    private long totalElements;
-    private boolean hasNext;
-    private boolean hasPrevious;
 
     public LikesStatusSearchListResponseDto toDo(Page<LikesDocument> likesDocuments) {
         return new LikesStatusSearchListResponseDto(
                 likesDocuments.stream().map(likesDocument -> new LikesStatusSearchResponseDto().toDo(likesDocument))
-                        .collect(Collectors.toList()),
-                likesDocuments.getNumber(),
-                likesDocuments.getSize(),
-                likesDocuments.getTotalPages(),
-                likesDocuments.getTotalElements(),
-                likesDocuments.hasNext(),
-                likesDocuments.hasPrevious()
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/LikesElasticSearchManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/LikesElasticSearchManagerImpl.java
@@ -86,12 +86,14 @@ public class LikesElasticSearchManagerImpl implements LikesElasticSearchManager 
 
     @Override
     @Transactional(readOnly = true)
-    public Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, Pageable pageable) {
+    public Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, long minPid, long maxPid) {
         NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
                 .withQuery(QueryBuilders.boolQuery()
                         .must(QueryBuilders.matchQuery("subAlbumId", subAlbumId))
-                        .must(QueryBuilders.matchQuery("nickname", nickname)))
-                .withPageable(pageable)
+                        .must(QueryBuilders.matchQuery("nickname", nickname))
+                        .must(QueryBuilders.rangeQuery("photoId").gte(minPid)
+                                .lte(maxPid))
+                )
                 .build();
 
         // 검색 결과 가져오기

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/LikesElasticSearchManager.java
@@ -13,6 +13,6 @@ public interface LikesElasticSearchManager {
     Page<LikesDocument> getPhotoLikesPaging(long photoId, Pageable pageable);
     void deleteByLikes(long id, String nickname);
     boolean isLikes(User user, long photoId);
-    Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, Pageable pageable);
+    Page<LikesDocument> getPhotoLikesStatus(long subAlbumId, String nickname, long minPid, long maxPid);
     void deleteByWildNickname(String nickname);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/LikesSearchService.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/LikesSearchService.java
@@ -31,15 +31,14 @@ public class LikesSearchService implements LikesSearchUseCase {
     @Override
     @CheckAlbumAccessRules
     public LikesStatusSearchListResponseDto getPhotoLikesStatus(LikesStatusSearchRequestDto likesStatusSearchRequestDto) {
-        Pageable pageable = PageRequest
-                .of(likesStatusSearchRequestDto.getPage(), likesStatusSearchRequestDto.getSize());
-
         return new LikesStatusSearchListResponseDto()
                 .toDo(likesElasticSearchManager
                         .getPhotoLikesStatus(
                                 likesStatusSearchRequestDto.getSubAlbumId(),
                                 getAuthentication.getAuthentication().getName(),
-                                pageable)
+                                likesStatusSearchRequestDto.getMinPid(),
+                                likesStatusSearchRequestDto.getMaxPid()
+                        )
                 );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
@@ -31,11 +31,15 @@ public class LikesDocument {
     @Field(type = FieldType.Keyword)
     private long subAlbumId;
 
+    @Field(type = FieldType.Text)
+    private String userProfileImage;
+
     public LikesDocument(User user, Photo photo) {
         this.id = photo.getId() + "_" + user.getNickname();
         this.photoId = photo.getId();
         this.nickname = user.getNickname();
         this.albumId = photo.getAlbum().getId();
         this.subAlbumId = photo.getSubAlbum().getId();
+        this.userProfileImage = user.getUserProfileImage();
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
+++ b/src/main/java/cord/eoeo/momentwo/member/application/service/AlbumMemberService.java
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.member.application.service;
 
 import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
 import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.LikesElasticSearchManager;
 import cord.eoeo.momentwo.member.adapter.in.dto.*;
 import cord.eoeo.momentwo.member.adapter.out.dto.AlbumMemberResponseDto;
 import cord.eoeo.momentwo.member.advice.exception.*;
@@ -30,6 +31,7 @@ public class AlbumMemberService implements AlbumMemberUseCase {
     private final GetMemberInfo getMemberInfo;
     private final GetAuthentication getAuthentication;
     private final AlbumManager albumManager;
+    private final LikesElasticSearchManager likesElasticSearchManager;
 
     @Override
     @Transactional
@@ -83,6 +85,7 @@ public class AlbumMemberService implements AlbumMemberUseCase {
 
             // 본인보다 낮은 권한만 추방 가능
             getAlbumInfo.doKickMember(kickMembersRequestDto.getAlbumId(), owner, kickedUser);
+            likesElasticSearchManager.deleteByWildNickname(kickedUser.getNickname());
         });
 
     }
@@ -149,6 +152,7 @@ public class AlbumMemberService implements AlbumMemberUseCase {
                 && getAlbumInfo.isCheckAlbumOneMember(memberOutRequestDto.getAlbumId())) {
             albumManager.albumDelete(member);
         }
+        likesElasticSearchManager.deleteByWildNickname(selfUser.getNickname());
     }
 
     // 멤버 초대


### PR DESCRIPTION
### 검색엔진 좋아요 수정
- 멤버 제외 시 좋아요에서 해당 멤버 삭제
- 사진 페이징 범위와 좋아요 페이징 범위를 동일화 할 필요가 있음
(기존엔 사진페이징 범위가 50이면, 좋아요도 50을 하게 되어 1~50 사이가 아닌 이후 값들도 가져오는 경우가 생겨 비효율 적이었음)

Resolve: #179 