### PR TITLE
클라우드 프론트 도메인 적용

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/config/s3/S3Manager.java
+++ b/src/main/java/cord/eoeo/momentwo/config/s3/S3Manager.java
@@ -17,6 +17,12 @@ public class S3Manager {
     @Value("${cloud.aws.s3.profiles-albums-path}")
     private String profileAlbumPath;
 
+    @Value("${cloud.aws.s3.profiles-users-path}")
+    private String profileUsersPath;
+
+    @Value("${cloud.aws.s3.domain}")
+    private String baseDomain;
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 }

--- a/src/main/java/cord/eoeo/momentwo/image/application/ImageService.java
+++ b/src/main/java/cord/eoeo/momentwo/image/application/ImageService.java
@@ -1,10 +1,14 @@
 package cord.eoeo.momentwo.image.application;
 
+import cord.eoeo.momentwo.album.application.port.out.AlbumManager;
+import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.config.s3.S3Manager;
 import cord.eoeo.momentwo.image.adapter.dto.PresignedRequestDto;
 import cord.eoeo.momentwo.image.adapter.dto.PresignedResponseDto;
 import cord.eoeo.momentwo.image.application.port.in.ImageUseCase;
 import cord.eoeo.momentwo.image.application.port.out.ImageManager;
+import cord.eoeo.momentwo.photo.advice.exception.PhotoCapacityFullException;
+import cord.eoeo.momentwo.photo.application.port.out.PhotoRepository;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,10 +18,17 @@ import org.springframework.stereotype.Service;
 public class ImageService implements ImageUseCase {
     private final ImageManager imageManager;
     private final S3Manager s3Manager;
+    private final PhotoRepository photoRepository;
+    private final AlbumManager albumManager;
 
     @Override
     @CheckAlbumAccessRules
     public PresignedResponseDto photoPresignedUrl(PresignedRequestDto presignedRequestDto) {
+        // 앨범 제한 갯수를 넘지 않는 다면 반환
+        Album album = albumManager.getAlbumInfo(presignedRequestDto.getAlbumId());
+        if(photoRepository.getAlbumCount(album) >= 1000) {
+            throw new PhotoCapacityFullException();
+        }
         return new PresignedResponseDto()
                 .toDo(imageManager.getPresignedUrl(presignedRequestDto.getExtension(), s3Manager.getImagePath()));
     }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoService.java
@@ -25,7 +25,6 @@ import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,10 +49,6 @@ public class PhotoService implements PhotoUseCase {
                 .orElseThrow(NotFoundUserException::new);
 
         Album album = albumManager.getAlbumInfo(photoUploadRequestDto.getAlbumId());
-        if(photoRepository.getAlbumCount(album) >= 1000) {
-            throw new PhotoCapacityFullException();
-        }
-
         SubAlbum subAlbum = subAlbumManager.getSubAlbumInfo(photoUploadRequestDto.getSubAlbumId());
 
         // 타입 정보 찾기
@@ -61,7 +56,13 @@ public class PhotoService implements PhotoUseCase {
         String type = PhotoFormat.findPhotoType(
                 photoUploadRequestDto.getFilename().split("\\.")[fileSplitSize].toUpperCase()).getType();
 
-        Photo newPhoto = new Photo(photoUploadRequestDto.getFilename(), type, user, album, subAlbum);
+        Photo newPhoto = new Photo(
+                s3Manager.getBaseDomain() + photoUploadRequestDto.getFilename(),
+                type,
+                user,
+                album,
+                subAlbum
+        );
 
         photoRepository.save(newPhoto);
     }


### PR DESCRIPTION
### 클라우드 프론트 도메인 적용
- 기존 이미지 조회 방식은 퍼블릭 액세스가 열려있어 모두가 접근할 수 있는 보안적인 문제가 발생
- 퍼블릭 액세스를 차단하고, 조회 시 클라우드 프론트에서만 접근할 수 있도록 수정
- 캐싱, 응답 속도 향상, 비용절감 등 이점이 발생하고 보안문제도 일부 해소할 수 있음

### 수정
- 업로드 시 사용하던 앨범 갯수 제한을 프리사인드 URL 요청 시에 적용하는 것으로 수정

Resolve: #198 