### PR TITLE
리프레시 토큰 저장방식 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/find/RefreshTokenFindByNicknameAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/find/RefreshTokenFindByNicknameAdapter.java
@@ -1,0 +1,20 @@
+package cord.eoeo.momentwo.user.adapter.out.find;
+
+import cord.eoeo.momentwo.user.application.port.out.find.RefreshTokenFindByNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.jpa.RefreshTokenFindJpaRepoExtend;
+import cord.eoeo.momentwo.user.domain.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenFindByNicknameAdapter implements RefreshTokenFindByNicknameRepo {
+    private final RefreshTokenFindJpaRepoExtend refreshTokenFindJpaRepoExtend;
+
+    @Override
+    public Optional<RefreshToken> findByNickname(String nickname) {
+        return refreshTokenFindJpaRepoExtend.findByNickname(nickname);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/find/RefreshTokenFindByNicknameRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/find/RefreshTokenFindByNicknameRepo.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.user.application.port.out.find;
+
+import cord.eoeo.momentwo.user.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenFindByNicknameRepo {
+    Optional<RefreshToken> findByNickname(String nickname);
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/jpa/RefreshTokenFindJpaRepoExtend.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/jpa/RefreshTokenFindJpaRepoExtend.java
@@ -1,0 +1,11 @@
+package cord.eoeo.momentwo.user.application.port.out.jpa;
+
+import cord.eoeo.momentwo.user.domain.RefreshToken;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface RefreshTokenFindJpaRepoExtend extends RefreshTokenFindJpaRepo {
+    @Query("SELECT r FROM RefreshToken r WHERE r.nickname = :nickname")
+    Optional<RefreshToken> findByNickname(String nickname);
+}


### PR DESCRIPTION
### 리프레시 토큰 저장방식 수정
- 지금 적용된 방식은 여러기기로 동시 접속을 했을 때 문제가 발생 함

### 변경 후
- 계정당 하나의 리프레시토큰 저장을 사용하여 중복 로그인을 방지하고, 토큰 관리를 깔끔하게 할 수 있도록 함
- 예를들면 하나의 계정이 두 기기에 시간을 두고 로그인을 했을 경우 두 기기 모두 자동로그인이 유지되거나,
- 타 기기에서 두개의 로그인이 존재할 수 있는 문제가 발생

### 수정 후
- 새 로그인 시도 시 DB 내의 RT가 존재한 경우 RT를 덮고 만료 날짜를 갱신시킨다.

Resolve: #205