### PR TITLE
블랙리스트 레디스 캐시로 관리 구현

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/config/security/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/config/security/handler/CustomLogoutSuccessHandler.java
@@ -14,6 +14,6 @@ public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
-        response.sendRedirect("/signout");
+        // 리다이렉션이 필요하거나, 로그아웃 성공 시 핸들함
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/config/security/jwt/adapter/out/BlackListRedisGenericAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/config/security/jwt/adapter/out/BlackListRedisGenericAdapter.java
@@ -1,0 +1,55 @@
+package cord.eoeo.momentwo.config.security.jwt.adapter.out;
+
+import cord.eoeo.momentwo.config.security.jwt.port.out.BlackListRedisGenericRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class BlackListRedisGenericAdapter implements BlackListRedisGenericRepo {
+    private final RedisTemplate<String, Object> redisStringTemplate;
+
+    @Override
+    public void set(String key, Object data) {
+        redisStringTemplate.opsForValue().set(key, data);
+    }
+
+    @Override
+    public void set(String key, Object data, Long duration) {
+        redisStringTemplate.opsForValue().set(key, data, duration);
+    }
+
+    @Override
+    public void setHash(String key, Object data) {
+        redisStringTemplate.opsForHash().putAll(key, (Map<?, ?>) data);
+    }
+
+    @Override
+    public String get(String key) {
+        return (String) redisStringTemplate.opsForValue().get(key);
+    }
+
+    @Override
+    public void update(String key, Object value) {
+        redisStringTemplate.opsForValue().set(key, value);
+    }
+
+    @Override
+    public void delete(String key) {
+        redisStringTemplate.delete(key);
+    }
+
+    @Override
+    public void expire(String key, Object time) {
+        redisStringTemplate.expire(key, (Long) time, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public long getExpire(String key) {
+        return redisStringTemplate.getExpire(key);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/config/security/jwt/port/out/BlackListRedisGenericRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/config/security/jwt/port/out/BlackListRedisGenericRepo.java
@@ -1,0 +1,6 @@
+package cord.eoeo.momentwo.config.security.jwt.port.out;
+
+import cord.eoeo.momentwo.global.application.port.out.RedisDefaultRepo;
+
+public interface BlackListRedisGenericRepo extends RedisDefaultRepo<String, Object, Long> {
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/in/status/UserLogOutController.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/in/status/UserLogOutController.java
@@ -14,7 +14,7 @@ public class UserLogOutController {
     private final UserBlackListTokenUseCase userBlackListTokenUseCase;
 
     // 로그아웃
-    @PostMapping("/logout")
+    @PostMapping("/users/logout")
     @ResponseStatus(HttpStatus.OK)
     public void logout(@RequestHeader("Authorization") String token) {
         String jwtToken = token.substring(7);

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/blacklist/UserBlackListTokenService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/blacklist/UserBlackListTokenService.java
@@ -1,17 +1,39 @@
 package cord.eoeo.momentwo.user.application.service.blacklist;
 
 import cord.eoeo.momentwo.config.security.jwt.port.out.JWTBlackList;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.application.port.in.blacklist.UserBlackListTokenUseCase;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
+import cord.eoeo.momentwo.user.application.port.out.RefreshTokenGenericRepo;
+import cord.eoeo.momentwo.user.application.port.out.find.RefreshTokenFindByNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.domain.RefreshToken;
+import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserBlackListTokenService implements UserBlackListTokenUseCase {
     private final JWTBlackList jwtBlackList;
+    private final RefreshTokenGenericRepo refreshTokenGenericRepo;
+    private final UserFindNicknameRepo userFindNicknameRepo;
+    private final GetAuthentication getAuthentication;
+    private final RefreshTokenFindByNicknameRepo refreshTokenFindByNicknameRepo;
 
     @Override
+    @Transactional
     public void blackListToken(String token) {
+        // 유저 정보 조회 및 RT 삭제
+        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
+                .orElseThrow(NotFoundUserException::new);
+        RefreshToken refreshToken = refreshTokenFindByNicknameRepo.findByNickname(user.getUsername())
+                .orElseThrow(NotFoundUserException::new);
+
+        refreshTokenGenericRepo.deleteById(refreshToken.getId());
+
+        // 블랙리스트 토큰 담기
         jwtBlackList.blackListToken(token);
     }
 }


### PR DESCRIPTION
### 블랙리스트 레디스 캐시로 관리 구현
- AT를 가지고 로그아웃 시 토큰을 블랙리스트로 만료시키고, 이 과정을 레디스 캐시에 보관하여 사용한다.
- 현재 스케쥴러에 의해 메모리 관리 -> 레디스 캐시로 자동관리 하도록 변경
- AT 만료 시 DB에 저장한 RT를 삭제하고 DB 자원 관리를 병행한다.
- 로그아웃 시 클라이언트(앱)에서 다음 화면으로 리다이랙션이 필요하다.

### 시큐리티 체인
- 시큐리티 체인 내에 로그아웃 핸들러를 비워놓고 나중에 필요한 경우 사용하도록 구조만 유지한다.

Resolve: #242 