### PR TITLE
유저 조회 캐싱 적용

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/out/GetAlbumMemberAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/out/GetAlbumMemberAdapter.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.album.adapter.out;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberPort;
 import cord.eoeo.momentwo.member.application.port.out.info.GetMemberInfoPort;
 import cord.eoeo.momentwo.member.domain.Member;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,15 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class GetAlbumMemberAdapter implements GetAlbumMemberPort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetMemberInfoPort getMemberInfoPort;
 
     @Override
     @Transactional(readOnly = true)
     public Member getMember(long albumId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         return getMemberInfoPort.getAlbumMemberInfo(albumId, user.getId());
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/out/GetAlbumMemberInfoAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/out/GetAlbumMemberInfoAdapter.java
@@ -4,9 +4,7 @@ import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberInfoPort;
 import cord.eoeo.momentwo.album.application.port.out.manager.GetAlbumInfoPort;
 import cord.eoeo.momentwo.member.application.port.out.info.GetMemberInfoPort;
 import cord.eoeo.momentwo.member.domain.Member;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,8 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetAlbumMemberInfoAdapter implements GetAlbumMemberInfoPort {
     private final GetAlbumInfoPort getAlbumInfoPort;
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetMemberInfoPort getMemberInfoPort;
 
     @Override
@@ -26,8 +23,7 @@ public class GetAlbumMemberInfoAdapter implements GetAlbumMemberInfoPort {
         // 앨범이 존재하는지 확인
         getAlbumInfoPort.getAlbumInfo(id);
 
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         return getMemberInfoPort.getAlbumMemberInfo(id, user.getId());
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/GetAlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/GetAlbumService.java
@@ -6,9 +6,7 @@ import cord.eoeo.momentwo.album.application.port.in.GetAlbumUseCase;
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.application.port.out.find.MemberFindAlbumByUserRepo;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,16 +17,15 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class GetAlbumService implements GetAlbumUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
     private final MemberFindAlbumByUserRepo memberFindAlbumByUserRepo;
+    private final UserNicknameValidPort userNicknameValidPort;
 
     @Override
     @CheckAlbumAccessRules
     @Transactional(readOnly = true)
     public AlbumInfoListResponseDto getAlbums() {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
+
         List<Album> albums = memberFindAlbumByUserRepo.findAlbumByUser(user);
         if(albums.isEmpty()) {
             throw new NotFoundAlbumException();

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentCreateAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentCreateAdapter.java
@@ -6,9 +6,7 @@ import cord.eoeo.momentwo.comment.domain.Comment;
 import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoGenericRepo;
 import cord.eoeo.momentwo.photo.domain.Photo;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,15 +14,13 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CommentCreateAdapter implements CommentCreatePort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final PhotoGenericRepo photoGenericRepo;
     private final CommentGenericRepo commentGenericRepo;
 
     @Override
     public void commentCreate(String comments, long photoId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         Photo photo = photoGenericRepo.findById(photoId).orElseThrow(NotFoundPhotoException::new);
 
         Comment comment = new Comment(comments, user, photo);

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentDeleteAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentDeleteAdapter.java
@@ -4,9 +4,7 @@ import cord.eoeo.momentwo.comment.advice.exception.NotCommentAccessException;
 import cord.eoeo.momentwo.comment.application.port.out.CommentGenericRepo;
 import cord.eoeo.momentwo.comment.application.port.out.find.CommentFindIdAndUserRepo;
 import cord.eoeo.momentwo.comment.application.port.out.manager.CommentDeletePort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,15 +12,13 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CommentDeleteAdapter implements CommentDeletePort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final CommentFindIdAndUserRepo commentFindIdAndUserRepo;
     private final CommentGenericRepo commentGenericRepo;
 
     @Override
     public void commentDelete(long commentId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         commentFindIdAndUserRepo.findByIdAndUser(commentId, user).orElseThrow(NotCommentAccessException::new);
         commentGenericRepo.deleteById(commentId);
     }

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentEditAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentEditAdapter.java
@@ -5,9 +5,7 @@ import cord.eoeo.momentwo.comment.application.port.out.CommentGenericRepo;
 import cord.eoeo.momentwo.comment.application.port.out.find.CommentFindIdAndUserRepo;
 import cord.eoeo.momentwo.comment.application.port.out.manager.CommentEditPort;
 import cord.eoeo.momentwo.comment.domain.Comment;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,15 +13,13 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class CommentEditAdapter implements CommentEditPort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final CommentFindIdAndUserRepo commentFindIdAndUserRepo;
     private final CommentGenericRepo commentGenericRepo;
 
     @Override
     public void commentEdit(String editComments, long commentId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         Comment comment = commentFindIdAndUserRepo.findByIdAndUser(commentId, user)
                 .orElseThrow(NotCommentAccessException::new);
         comment.setComments(editComments);

--- a/src/main/java/cord/eoeo/momentwo/description/adapter/out/manager/DescriptionGetPhotoAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/description/adapter/out/manager/DescriptionGetPhotoAdapter.java
@@ -4,9 +4,7 @@ import cord.eoeo.momentwo.description.application.port.out.manager.DescriptionGe
 import cord.eoeo.momentwo.photo.advice.exception.NotPhotoAccessException;
 import cord.eoeo.momentwo.photo.application.port.out.find.PhotoFindIdAndUserPort;
 import cord.eoeo.momentwo.photo.domain.Photo;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,14 +12,13 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class DescriptionGetPhotoAdapter implements DescriptionGetPhotoPort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final PhotoFindIdAndUserPort photoFindIdAndUserPort;
 
     @Override
     public Photo getPhoto(long photoId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
+
         return photoFindIdAndUserPort.findByIdAndUser(photoId, user)
                 .orElseThrow(NotPhotoAccessException::new);
     }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/UserSearchService.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/UserSearchService.java
@@ -4,9 +4,7 @@ import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.UserSearchRequestDto;
 import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.UserSearchListResponseDto;
 import cord.eoeo.momentwo.elasticsearch.application.port.in.UserSearchUseCase;
 import cord.eoeo.momentwo.elasticsearch.application.port.out.UserElasticSearchManager;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -17,13 +15,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserSearchService implements UserSearchUseCase {
     private final UserElasticSearchManager userElasticSearchManager;
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
 
     @Override
     public UserSearchListResponseDto getUserElasticSearch(UserSearchRequestDto userSearchRequestDto) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                        .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         Pageable pageable = PageRequest.of(userSearchRequestDto.getPage(), userSearchRequestDto.getSize());
 

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/DeleteFriendsService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/DeleteFriendsService.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.RequestFriendshipDto;
 import cord.eoeo.momentwo.friendship.application.port.in.DeleteFriendsUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.DeleteFriendsPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,18 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DeleteFriendsService implements DeleteFriendsUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final DeleteFriendsPort deleteFriendsPort;
 
     // 친구 삭제
     @Override
     @Transactional
     public void deleteFriends(RequestFriendshipDto requestFriendshipDto) {
-        User toUser = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
-        User fromUser = userFindNicknameRepo.findByNickname(requestFriendshipDto.getNickname())
-                .orElseThrow(NotFoundUserException::new);
+        User toUser = userNicknameValidPort.authenticationValid();
+        User fromUser = userNicknameValidPort.userNicknameValid(requestFriendshipDto.getNickname());
 
         deleteFriendsPort.deleteFriends(toUser, fromUser);
     }

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipReceiveService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipReceiveService.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.FriendshipReceiveListResponseDto;
 import cord.eoeo.momentwo.friendship.application.port.in.GetFriendshipReceiveUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.GetFriendshipReceivePort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,16 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class GetFriendshipReceiveService implements GetFriendshipReceiveUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetFriendshipReceivePort getFriendshipReceivePort;
 
     // 받은 친구목록 조회
     @Override
     @Transactional(readOnly = true)
     public FriendshipReceiveListResponseDto getFriendshipReceive() {
-        User owner = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User owner = userNicknameValidPort.authenticationValid();
+
         return getFriendshipReceivePort.getFriendshipReceive(owner);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipSendService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipSendService.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.FriendshipSendListResponseDto;
 import cord.eoeo.momentwo.friendship.application.port.in.GetFriendshipSendUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.GetFriendshipSendPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,16 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class GetFriendshipSendService implements GetFriendshipSendUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetFriendshipSendPort getFriendshipSendPort;
 
     // 보낸 친구목록 조회
     @Override
     @Transactional(readOnly = true)
     public FriendshipSendListResponseDto getFriendshipSend() {
-        User owner = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User owner = userNicknameValidPort.authenticationValid();
+
         return getFriendshipSendPort.getFriendshipSend(owner);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/GetFriendshipService.java
@@ -3,10 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.FriendshipAllListResponseDto;
 import cord.eoeo.momentwo.friendship.application.port.in.GetFriendshipUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.GetAllFriendship;
-import cord.eoeo.momentwo.friendship.application.port.out.process.GetFriendshipPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -16,16 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class GetFriendshipService implements GetFriendshipUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetAllFriendship getAllFriendship;
 
     // 친구목록 조회
     @Override
     @Transactional(readOnly = true)
     public FriendshipAllListResponseDto getFriendship(int size, long cursor) {
-        User owner = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User owner = userNicknameValidPort.authenticationValid();
+
         return getAllFriendship.getAllFriendship(owner, PageRequest.of(0, size), cursor);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/RequestFriendshipCancelService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/RequestFriendshipCancelService.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.RequestFriendshipDto;
 import cord.eoeo.momentwo.friendship.application.port.in.RequestFriendshipCancelUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.RequestCancelPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,21 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class RequestFriendshipCancelService implements RequestFriendshipCancelUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final RequestCancelPort requestCancelPort;
 
     // 친구 요청 취소
     @Override
     @Transactional
     public void requestFriendshipCancel(RequestFriendshipDto requestFriendshipDto) {
-        User fromUser = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName()).orElseThrow(
-                NotFoundUserException::new
-        );
+        User fromUser = userNicknameValidPort.authenticationValid();
         // 사용자 조회
-        User toUser = userFindNicknameRepo.findByNickname(requestFriendshipDto.getNickname()).orElseThrow(
-                NotFoundUserException::new
-        );
+        User toUser = userNicknameValidPort.userNicknameValid(requestFriendshipDto.getNickname());
 
         requestCancelPort.requestCancel(fromUser, toUser);
     }

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/RequestFriendshipService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/RequestFriendshipService.java
@@ -6,9 +6,7 @@ import cord.eoeo.momentwo.friendship.advice.exception.SelfRequestException;
 import cord.eoeo.momentwo.friendship.application.port.in.RequestFriendshipUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.FriendsRequestPort;
 import cord.eoeo.momentwo.friendship.application.port.out.process.IsRequestFriendsPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class RequestFriendshipService implements RequestFriendshipUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final IsRequestFriendsPort isRequestFriendsPort;
     private final FriendsRequestPort friendsRequestPort;
 
@@ -26,16 +23,12 @@ public class RequestFriendshipService implements RequestFriendshipUseCase {
     @Override
     @Transactional
     public void requestFriendship(RequestFriendshipDto requestFriendshipDto) {
-        User fromUser = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName()).orElseThrow(
-                NotFoundUserException::new
-        );
+        User fromUser = userNicknameValidPort.authenticationValid();
         if(fromUser.getNickname().equals(requestFriendshipDto.getNickname())) {
             throw new SelfRequestException();
         }
         // 사용자 조회
-        User toUser = userFindNicknameRepo.findByNickname(requestFriendshipDto.getNickname()).orElseThrow(
-                NotFoundUserException::new
-        );
+        User toUser = userNicknameValidPort.userNicknameValid(requestFriendshipDto.getNickname());
 
         // 친구요청을 보냈었는지 확인
         if(!isRequestFriendsPort.isRequestFriends(fromUser, toUser)) {

--- a/src/main/java/cord/eoeo/momentwo/friendship/application/service/ResponseFriendshipService.java
+++ b/src/main/java/cord/eoeo/momentwo/friendship/application/service/ResponseFriendshipService.java
@@ -3,9 +3,7 @@ package cord.eoeo.momentwo.friendship.application.service;
 import cord.eoeo.momentwo.friendship.adapter.dto.ResponseFriendshipDto;
 import cord.eoeo.momentwo.friendship.application.port.in.ResponseFriendshipUseCase;
 import cord.eoeo.momentwo.friendship.application.port.out.process.ResponseProcessPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,20 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ResponseFriendshipService implements ResponseFriendshipUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final ResponseProcessPort responseProcessPort;
 
     // 친구요청 응답 (수락 & 거절)
     @Override
     @Transactional
     public void responseFriendship(ResponseFriendshipDto responseFriendshipDto) {
-        User responseUser = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName()).orElseThrow(
-                NotFoundUserException::new
-        );
-        User requestUser = userFindNicknameRepo.findByNickname(responseFriendshipDto.getNickname()).orElseThrow(
-                NotFoundUserException::new
-        );
+        User responseUser = userNicknameValidPort.authenticationValid();
+        User requestUser = userNicknameValidPort.userNicknameValid(responseFriendshipDto.getNickname());
 
         // 수락 시 false -> true
         // 거절 시 data 삭제

--- a/src/main/java/cord/eoeo/momentwo/global/advice/GlobalExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/global/advice/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.global.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    // DTO에서 패턴에 따른 예외처리 적용
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String dtoValidation(final MethodArgumentNotValidException e) {
+        return Objects.requireNonNull(e.getFieldError()).getDefaultMessage();
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/image/application/service/UserProfilePresignedUrlService.java
+++ b/src/main/java/cord/eoeo/momentwo/image/application/service/UserProfilePresignedUrlService.java
@@ -6,9 +6,7 @@ import cord.eoeo.momentwo.image.adapter.dto.UserPresignedRequestDto;
 import cord.eoeo.momentwo.image.application.port.in.UserProfilePresignedUrlUseCase;
 import cord.eoeo.momentwo.image.application.port.out.ImageDeletePort;
 import cord.eoeo.momentwo.image.application.port.out.MakeImagePresignedUrlPort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,16 +14,14 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserProfilePresignedUrlService implements UserProfilePresignedUrlUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final ImageDeletePort imageDeletePort;
     private final MakeImagePresignedUrlPort makeImagePresignedUrlPort;
     private final S3Manager s3Manager;
 
     @Override
     public PresignedResponseDto userProfilePresignedUrl(UserPresignedRequestDto userPresignedRequestDto) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         // 이미지 삭제(현재) -> 기존 이미지가 없다면 업로드한 이미지만 저장, 기존 이미지가 있다면 삭제 진행
         imageDeletePort.imageDelete(s3Manager.getProfileUsersPath() + user.getUserProfileImage()).join();

--- a/src/main/java/cord/eoeo/momentwo/like/adapter/out/manager/DoLikesAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/like/adapter/out/manager/DoLikesAdapter.java
@@ -10,9 +10,7 @@ import cord.eoeo.momentwo.like.domain.PhotoLike;
 import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoGenericRepo;
 import cord.eoeo.momentwo.photo.domain.Photo;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,8 +18,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class DoLikesAdapter implements DoLikesPort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final PhotoGenericRepo photoGenericRepo;
     private final LikesElasticSearchManager likesElasticSearchManager;
     private final PhotoLikesFindByPhotoPort photoLikesFindByPhotoPort;
@@ -31,8 +28,7 @@ public class DoLikesAdapter implements DoLikesPort {
 
     @Override
     public void doLikes(long photoId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         Photo photo = photoGenericRepo.findById(photoId).orElseThrow(NotFoundPhotoException::new);
 
 

--- a/src/main/java/cord/eoeo/momentwo/like/adapter/out/manager/UnDoLikesAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/like/adapter/out/manager/UnDoLikesAdapter.java
@@ -11,9 +11,7 @@ import cord.eoeo.momentwo.like.domain.PhotoLike;
 import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoGenericRepo;
 import cord.eoeo.momentwo.photo.domain.Photo;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -21,8 +19,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class UnDoLikesAdapter implements UnDoLikesPort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final LikesElasticSearchManager likesElasticSearchManager;
     private final PhotoGenericRepo photoGenericRepo;
     private final PhotoLikesFindByPhotoPort photoLikesFindByPhotoPort;
@@ -32,8 +29,7 @@ public class UnDoLikesAdapter implements UnDoLikesPort {
 
     @Override
     public void undoLikes(long photoId) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         // 검색엔진에 좋아요를 누른상태면 삭제 진행
         if(likesElasticSearchManager.isLikes(user, photoId)) {

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/out/async/GetUserInfoByNicknameAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/out/async/GetUserInfoByNicknameAdapter.java
@@ -1,8 +1,7 @@
 package cord.eoeo.momentwo.member.adapter.out.async;
 
 import cord.eoeo.momentwo.member.application.port.out.async.GetUserInfoByNicknamePort;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -14,13 +13,14 @@ import java.util.concurrent.CompletableFuture;
 @Component
 @RequiredArgsConstructor
 public class GetUserInfoByNicknameAdapter implements GetUserInfoByNicknamePort {
-    private final UserFindNicknameRepo userFindNicknameRepo;
+    private final UserNicknameValidPort userNicknameValidPort;
 
     @Override
     @Transactional(readOnly = true)
     @Async
     public CompletableFuture<User> getUserInfoByNickname(String nickname) {
         return CompletableFuture.supplyAsync(()
-                -> userFindNicknameRepo.findByNickname(nickname).orElseThrow(NotFoundUserException::new));
+                -> userNicknameValidPort.userNicknameValid(nickname)
+        );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoMoveService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoMoveService.java
@@ -13,9 +13,7 @@ import cord.eoeo.momentwo.subAlbum.advice.exception.NotFoundSubAlbumException;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import cord.eoeo.momentwo.subAlbum.application.port.out.get.GetSubAlbumInfoRepo;
 import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,8 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PhotoMoveService implements PhotoMoveUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetSubAlbumInfoRepo getSubAlbumInfoRepo;
     private final PhotoGenericRepo photoGenericRepo;
     private final MoveCheckAdminOrSelfPort moveCheckAdminOrSelfPort;
@@ -37,8 +34,7 @@ public class PhotoMoveService implements PhotoMoveUseCase {
     @Transactional
     public void photoMove(PhotoMoveRequestDto photoMoveRequestDto) {
         // 유저 정보 확인
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         // 이동할 서브앨범이 존재하는지 확인
         SubAlbum moveSubAlbum = getSubAlbumInfoRepo.getSubAlbumInfo(photoMoveRequestDto.getMoveSubAlbumId())

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoUploadService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoUploadService.java
@@ -11,9 +11,7 @@ import cord.eoeo.momentwo.photo.domain.PhotoFormat;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import cord.eoeo.momentwo.subAlbum.application.port.out.manager.GetSubAlbumInfoPort;
 import cord.eoeo.momentwo.subAlbum.domain.SubAlbum;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,8 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class PhotoUploadService implements PhotoUploadUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final GetAlbumInfoPort getAlbumInfoPort;
     private final GetSubAlbumInfoPort getSubAlbumInfoPort;
     private final S3Manager s3Manager;
@@ -34,8 +31,7 @@ public class PhotoUploadService implements PhotoUploadUseCase {
     @CheckAlbumAccessRules
     public void photoUpload(PhotoUploadRequestDto photoUploadRequestDto) {
         // 유저 정보 및 앨범 정보 가져오기
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         Album album = getAlbumInfoPort.getAlbumInfo(photoUploadRequestDto.getAlbumId());
         SubAlbum subAlbum = getSubAlbumInfoPort.getSubAlbumInfo(photoUploadRequestDto.getSubAlbumId());

--- a/src/main/java/cord/eoeo/momentwo/subAlbum/application/aop/CheckAlbumAccessRulesAspect.java
+++ b/src/main/java/cord/eoeo/momentwo/subAlbum/application/aop/CheckAlbumAccessRulesAspect.java
@@ -2,9 +2,7 @@ package cord.eoeo.momentwo.subAlbum.application.aop;
 
 import cord.eoeo.momentwo.member.advice.exception.NotFoundAccessException;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoRulesCheck;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
@@ -19,8 +17,7 @@ import java.lang.reflect.Field;
 @RequiredArgsConstructor
 public class CheckAlbumAccessRulesAspect {
     private final PhotoRulesCheck photoRulesCheck;
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
 
     @Before("@annotation(cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules)")
     public void checkAlbumAccessRules(JoinPoint joinPoint) throws Exception{
@@ -42,8 +39,7 @@ public class CheckAlbumAccessRulesAspect {
                 }
             }
         }
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         if(albumId != 0 && !photoRulesCheck.isAlbumMember(albumId, user)) {
             throw new NotFoundAccessException();

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/UserLoginRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/dto/in/UserLoginRequestDto.java
@@ -3,16 +3,19 @@ package cord.eoeo.momentwo.user.adapter.dto.in;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Data
 @AllArgsConstructor
 public class UserLoginRequestDto {
     // id
+    @NotBlank(message = "이메일을 입력해주세요.")
     @Pattern(regexp = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$",
             message = "이메일 형식을 지켜주세요.")
     private String username;
     // password
+    @NotBlank(message = "패스워드를 입력해주세요.")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&])[A-Za-z[0-9]$@$!%*#?&]{8,20}$",
             message = "비밀번호는 8이상 20자리 특수문자, 영문, 숫자 조합 형식을 지켜주세요.")
     private String password;

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UserNicknameValidAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UserNicknameValidAdapter.java
@@ -1,0 +1,80 @@
+package cord.eoeo.momentwo.user.adapter.out.valid;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
+import cord.eoeo.momentwo.user.application.port.out.UserRedisGenericRepo;
+import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidKeyPort;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserNicknameValidAdapter implements UserNicknameValidPort {
+    private final UserFindNicknameRepo userFindNicknameRepo;
+    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidKeyPort userNicknameValidKeyPort;
+    private final UserRedisGenericRepo userRedisGenericRepo;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public User authenticationValid() {
+        // 캐싱 정보 조회
+        String nickname = getAuthentication.getAuthentication().getName();
+        String key = userNicknameValidKeyPort.getKey(nickname);
+        Object isGetRedis = userRedisGenericRepo.get(key);
+
+        if(isGetRedis != null) {
+            try {
+                return objectMapper.readValue(String.valueOf(isGetRedis), User.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // DB 데이터 조회
+        User user = userFindNicknameRepo.findByNickname(nickname).orElseThrow(NotFoundUserException::new);
+
+        // 캐시에 데이터 저장
+        try {
+            userRedisGenericRepo.set(key, objectMapper.writeValueAsString(user));
+            userRedisGenericRepo.expire(key, 10L);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return user;
+    }
+
+    @Override
+    public User userNicknameValid(String nickname) {
+        // 캐싱 정보 조회
+        String key = userNicknameValidKeyPort.getKey(nickname);
+        Object isGetRedis = userRedisGenericRepo.get(key);
+
+        if(isGetRedis != null) {
+            try {
+                return objectMapper.readValue(String.valueOf(isGetRedis), User.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // DB 데이터 조회
+        User user = userFindNicknameRepo.findByNickname(nickname).orElseThrow(NotFoundUserException::new);
+
+        // 캐시에 데이터 저장
+        try {
+            userRedisGenericRepo.set(key, objectMapper.writeValueAsString(user));
+            userRedisGenericRepo.expire(key, 10L);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return user;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UserNicknameValidKeyAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UserNicknameValidKeyAdapter.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.user.adapter.out.valid;
+
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidKeyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserNicknameValidKeyAdapter implements UserNicknameValidKeyPort {
+
+    @Override
+    public String getKey(String nickname) {
+        return "nickname/" + nickname;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UsernameValidAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UsernameValidAdapter.java
@@ -1,0 +1,49 @@
+package cord.eoeo.momentwo.user.adapter.out.valid;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
+import cord.eoeo.momentwo.user.application.port.out.UserRedisGenericRepo;
+import cord.eoeo.momentwo.user.application.port.out.find.UserFindUsernameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UsernameValidKeyPort;
+import cord.eoeo.momentwo.user.application.port.out.valid.UsernameValidPort;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UsernameValidAdapter implements UsernameValidPort {
+    private final UserFindUsernameRepo userFindUsernameRepo;
+    private final UsernameValidKeyPort usernameValidKeyPort;
+    private final UserRedisGenericRepo userRedisGenericRepo;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public User usernameValid(String username) {
+        // 캐싱 정보 조회
+        String key = usernameValidKeyPort.getKey(username);
+        Object isGetRedis = userRedisGenericRepo.get(key);
+
+        if(isGetRedis != null) {
+            try {
+                return objectMapper.readValue(String.valueOf(isGetRedis), User.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // DB 데이터 조회
+        User user = userFindUsernameRepo.findByUsername(username).orElseThrow(NotFoundUserException::new);
+
+        // 캐시에 데이터 저장
+        try {
+            userRedisGenericRepo.set(key, objectMapper.writeValueAsString(user));
+            userRedisGenericRepo.expire(key, 10L);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return user;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UsernameValidKeyAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/user/adapter/out/valid/UsernameValidKeyAdapter.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.user.adapter.out.valid;
+
+import cord.eoeo.momentwo.user.application.port.out.valid.UsernameValidKeyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UsernameValidKeyAdapter implements UsernameValidKeyPort {
+
+    @Override
+    public String getKey(String username) {
+        return "username/" + username;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UserNicknameValidKeyPort.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UserNicknameValidKeyPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.user.application.port.out.valid;
+
+public interface UserNicknameValidKeyPort {
+    String getKey(String nickname);
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UserNicknameValidPort.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UserNicknameValidPort.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.user.application.port.out.valid;
+
+import cord.eoeo.momentwo.user.domain.User;
+
+public interface UserNicknameValidPort {
+    User authenticationValid();
+
+    User userNicknameValid(String nickname);
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UsernameValidKeyPort.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UsernameValidKeyPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.user.application.port.out.valid;
+
+public interface UsernameValidKeyPort {
+    String getKey(String username);
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UsernameValidPort.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/port/out/valid/UsernameValidPort.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.user.application.port.out.valid;
+
+
+import cord.eoeo.momentwo.user.domain.User;
+
+public interface UsernameValidPort {
+    User usernameValid(String username);
+}

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/blacklist/UserBlackListTokenService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/blacklist/UserBlackListTokenService.java
@@ -3,10 +3,9 @@ package cord.eoeo.momentwo.user.application.service.blacklist;
 import cord.eoeo.momentwo.config.security.jwt.port.out.JWTBlackList;
 import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.application.port.in.blacklist.UserBlackListTokenUseCase;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
 import cord.eoeo.momentwo.user.application.port.out.RefreshTokenGenericRepo;
 import cord.eoeo.momentwo.user.application.port.out.find.RefreshTokenFindByNicknameRepo;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.RefreshToken;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -18,16 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserBlackListTokenService implements UserBlackListTokenUseCase {
     private final JWTBlackList jwtBlackList;
     private final RefreshTokenGenericRepo refreshTokenGenericRepo;
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final RefreshTokenFindByNicknameRepo refreshTokenFindByNicknameRepo;
 
     @Override
     @Transactional
     public void blackListToken(String token) {
         // 유저 정보 조회 및 RT 삭제
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
         RefreshToken refreshToken = refreshTokenFindByNicknameRepo.findByNickname(user.getUsername())
                 .orElseThrow(NotFoundUserException::new);
 

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/profile/UserProfileImageUploadService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/profile/UserProfileImageUploadService.java
@@ -1,13 +1,15 @@
 package cord.eoeo.momentwo.user.application.service.profile;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import cord.eoeo.momentwo.config.s3.S3Manager;
 import cord.eoeo.momentwo.elasticsearch.application.port.out.UserElasticSearchManager;
 import cord.eoeo.momentwo.user.adapter.dto.in.UserProfileUploadRequestDto;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.application.port.in.profile.UserProfileImageUploadUseCase;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
 import cord.eoeo.momentwo.user.application.port.out.UserGenericRepo;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.UserRedisGenericRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidKeyPort;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,20 +18,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserProfileImageUploadService implements UserProfileImageUploadUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final S3Manager s3Manager;
     private final UserGenericRepo userGenericRepo;
     private final UserElasticSearchManager userElasticSearchManager;
+    private final UserNicknameValidKeyPort userNicknameValidKeyPort;
+    private final UserRedisGenericRepo userRedisGenericRepo;
+    private final ObjectMapper objectMapper;
 
     @Override
     @Transactional
     public void usersProfilesImageUpload(UserProfileUploadRequestDto userProfileUploadRequestDto) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
 
         user.setUserProfileImage(s3Manager.getBaseDomain() + userProfileUploadRequestDto.getFilename());
         userGenericRepo.save(user);
         userElasticSearchManager.userInfoChange(user);
+
+        // 캐싱된 데이터가 있다면 덮어쓰자
+        String key = userNicknameValidKeyPort.getKey(user.getNickname());
+        Object isGetRedis = userRedisGenericRepo.get(key);
+
+        if(isGetRedis != null) {
+            // 캐시에 데이터 저장
+            try {
+                userRedisGenericRepo.set(key, objectMapper.writeValueAsString(user));
+                userRedisGenericRepo.expire(key, 10L);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/profile/UserProfileService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/profile/UserProfileService.java
@@ -2,11 +2,10 @@ package cord.eoeo.momentwo.user.application.service.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cord.eoeo.momentwo.user.adapter.dto.out.UserProfileResponseDto;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.application.port.in.profile.UserProfileKeyPort;
 import cord.eoeo.momentwo.user.application.port.in.profile.UserProfileUseCase;
 import cord.eoeo.momentwo.user.application.port.out.UserRedisGenericRepo;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserProfileService implements UserProfileUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final UserRedisGenericRepo userRedisGenericRepo;
     private final UserProfileKeyPort userProfileKeyPort;
     private final ObjectMapper objectMapper;
@@ -31,7 +30,7 @@ public class UserProfileService implements UserProfileUseCase {
         }
 
         // DB 확인
-        User user = userFindNicknameRepo.findByNickname(nickname).orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.userNicknameValid(nickname);
         UserProfileResponseDto profileResponseDto = new UserProfileResponseDto().toDo(user);
 
         // 캐시에 데이터 저장

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserInfoService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserInfoService.java
@@ -1,9 +1,8 @@
 package cord.eoeo.momentwo.user.application.service.status;
 
 import cord.eoeo.momentwo.user.adapter.dto.out.LoginInfoResponse;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.application.port.in.status.UserInfoUseCase;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindUsernameRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UsernameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,11 +10,12 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserInfoService implements UserInfoUseCase {
-    private final UserFindUsernameRepo userFindUsernameRepo;
+    private final UsernameValidPort usernameValidPort;
 
     @Override
     public LoginInfoResponse getUserInfo(String username) {
-        User user = userFindUsernameRepo.findByUsername(username).orElseThrow(NotFoundUserException::new);
+        User user = usernameValidPort.usernameValid(username);
+
         return new LoginInfoResponse().toDo(user);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserSignInService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserSignInService.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.concurrent.CompletionException;
-
 @Service
 @RequiredArgsConstructor
 public class UserSignInService implements UserSignInUseCase {
@@ -30,11 +28,11 @@ public class UserSignInService implements UserSignInUseCase {
     @Transactional
     public TokenResponseDto signIn(UserLoginRequestDto userLoginRequestDto) {
         // 아이디 확인
-        User user = userFindUsernameRepo.findByUsername(userLoginRequestDto.getUsername()).orElseThrow(
-                () -> new CompletionException(new NotFoundUserException()));
+        User user = userFindUsernameRepo.findByUsername(userLoginRequestDto.getUsername())
+                .orElseThrow(NotFoundUserException::new);
         // 비밀번호 확인
         if(!passwordEncoder.matches(userLoginRequestDto.getPassword(), user.getPassword())) {
-            throw new CompletionException(new PasswordMisMatchException());
+            throw new PasswordMisMatchException();
         }
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                 userLoginRequestDto.getUsername(),

--- a/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserSignOutService.java
+++ b/src/main/java/cord/eoeo/momentwo/user/application/service/status/UserSignOutService.java
@@ -10,13 +10,11 @@ import cord.eoeo.momentwo.member.application.port.out.info.IsCheckAlbumAdminPort
 import cord.eoeo.momentwo.member.application.port.out.info.IsCheckAlbumOneMemberPort;
 import cord.eoeo.momentwo.member.domain.Member;
 import cord.eoeo.momentwo.user.adapter.dto.in.SignOutRequestDto;
-import cord.eoeo.momentwo.user.advice.exception.NotFoundUserException;
 import cord.eoeo.momentwo.user.advice.exception.PasswordMisMatchException;
 import cord.eoeo.momentwo.user.application.port.in.status.UserSignOutUseCase;
-import cord.eoeo.momentwo.user.application.port.out.GetAuthentication;
 import cord.eoeo.momentwo.user.application.port.out.PasswordEncoder;
-import cord.eoeo.momentwo.user.application.port.out.find.UserFindNicknameRepo;
 import cord.eoeo.momentwo.user.application.port.out.jpa.UserDeleteJpaRepo;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,8 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserSignOutService implements UserSignOutUseCase {
-    private final UserFindNicknameRepo userFindNicknameRepo;
-    private final GetAuthentication getAuthentication;
+    private final UserNicknameValidPort userNicknameValidPort;
     private final PasswordEncoder passwordEncoder;
     private final GetAlbumIdByAdminUserPort getAlbumIdByAdminUserPort;
     private final GetMemberInfoPort getMemberInfoPort;
@@ -41,8 +38,8 @@ public class UserSignOutService implements UserSignOutUseCase {
     @Override
     @Transactional
     public void signOut(SignOutRequestDto signOutRequestDto) {
-        User user = userFindNicknameRepo.findByNickname(getAuthentication.getAuthentication().getName())
-                .orElseThrow(NotFoundUserException::new);
+        User user = userNicknameValidPort.authenticationValid();
+
         // 비밀번호 확인
         if(!passwordEncoder.matches(signOutRequestDto.getPassword(), user.getPassword())) {
             throw new PasswordMisMatchException();


### PR DESCRIPTION
### 유저 조회 캐싱 적용
- 현재 동작하고 있는 대체적인 기능에서 유저 조회를 사용하고 있는데, 기존과 같은 조회 방법이라면 DB 조회가 많아 cost가 상당함.
- 해당 부분을 짧은 TTL로 만들어 캐싱한다면 엄청난 비용 감소를 만들 수 있음.
- 단, 유저 정보에 변경이 있다면 캐시 갱신을 해줘야함.

### Exception
- Valid에서 검증 예외를 던지지 않아 글로벌 핸들러를 추가