### PR TITLE
좋아요 검색문서 타입 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/LikesElasticSearchManagerImpl.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/LikesElasticSearchManagerImpl.java
@@ -12,6 +12,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -91,9 +92,9 @@ public class LikesElasticSearchManagerImpl implements LikesElasticSearchManager 
                 .withQuery(QueryBuilders.boolQuery()
                         .must(QueryBuilders.matchQuery("subAlbumId", subAlbumId))
                         .must(QueryBuilders.matchQuery("nickname", nickname))
-                        .must(QueryBuilders.rangeQuery("photoId").gte(minPid)
-                                .lte(maxPid))
+                        .must(QueryBuilders.rangeQuery("photoId").gte(minPid).lte(maxPid))
                 )
+                .withPageable(PageRequest.of(0, 20))
                 .build();
 
         // 검색 결과 가져오기

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/LikesDocument.java
@@ -19,16 +19,16 @@ public class LikesDocument {
     @Id
     private String id;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Long)
     private long photoId;
 
     @Field(type = FieldType.Keyword)
     private String nickname;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Long)
     private long albumId;
 
-    @Field(type = FieldType.Keyword)
+    @Field(type = FieldType.Long)
     private long subAlbumId;
 
     @Field(type = FieldType.Text)


### PR DESCRIPTION
### 좋아요 검색문서 타입 수정
- 본인이 누른 좋아요 처리 시 Range 범위가 Keyword 타입이라 정상동작하지 않는 오류를 발견
- long 타입으로 수정
- 또한, 조회 시 따로 size 설정이 없으면 default 10개 조회이기 때문에 우리 사진 반환 갯수에 맞춰 수정

Resolve: #250 