### PR TITLE
앨범 RUD 작업에서 어드민만 가능하도록 수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/out/manager/AlbumS3ImageDeleteAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/out/manager/AlbumS3ImageDeleteAdapter.java
@@ -1,0 +1,29 @@
+package cord.eoeo.momentwo.album.adapter.out.manager;
+
+import cord.eoeo.momentwo.album.application.port.out.manager.AlbumS3ImageDeletePort;
+import cord.eoeo.momentwo.config.s3.S3Manager;
+import cord.eoeo.momentwo.image.application.port.out.ImageListDeletePort;
+import cord.eoeo.momentwo.photo.application.port.out.find.PhotoFindAllImagePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumS3ImageDeleteAdapter implements AlbumS3ImageDeletePort {
+    private final PhotoFindAllImagePort photoFindAllImagePort;
+    private final ImageListDeletePort imageListDeletePort;
+    private final S3Manager s3Manager;
+
+    @Override
+    public void s3ImageDelete(long albumId) {
+        List<String> keys = photoFindAllImagePort.photoFindAllImage(albumId);
+        int batchSize = 1000;
+        keys.parallelStream()
+                .map(key -> key.substring(s3Manager.getBaseDomain().length()))
+                .collect(Collectors.groupingBy(key -> keys.indexOf(key) / batchSize))
+                .forEach((group, batch) -> imageListDeletePort.imageListDelete(batch));
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/aop/CheckAlbumAdminAspect.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/aop/CheckAlbumAdminAspect.java
@@ -1,30 +1,52 @@
 package cord.eoeo.momentwo.album.application.aop;
 
 import cord.eoeo.momentwo.album.advice.exception.NotAlbumAdminException;
-import cord.eoeo.momentwo.member.domain.Member;
+import cord.eoeo.momentwo.member.application.port.out.find.MemberFindGradeByAlbumIdAndUserIdRepo;
 import cord.eoeo.momentwo.member.domain.MemberAlbumGrade;
+import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
 
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class CheckAlbumAdminAspect {
+    private final MemberFindGradeByAlbumIdAndUserIdRepo memberFindGradeByAlbumIdAndUserIdRepo;
+    private final UserNicknameValidPort userNicknameValidPort;
 
-    @After("@annotation(cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin)")
-    public void checkAlbumAdmin(JoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
+    @Before("@annotation(cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin)")
+    public void checkAlbumAdmin(JoinPoint joinPoint) throws Exception {
+        Object[] values = joinPoint.getArgs();
+        long albumId = 0;
 
-        Member member = null;
+        for(int i = 0; i < values.length; i++) {
+            if(values[i] instanceof Long) {
+                albumId = (long) values[i];
+                break;
+            }
 
-        for (int i = 0; i < args.length; i++) {
-            if (args[i] instanceof Member) {
-                member = (Member) args[i];
+            Field[] o = values[i].getClass().getDeclaredFields();
+            for (Field f : o) {
+                if (f.getName().equals("albumId")) {
+                    f.setAccessible(true);
+                    albumId = (long) f.get(values[i]);
+                    break;
+                }
             }
         }
 
-        if(member != null && !member.getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN)) {
+        User user = userNicknameValidPort.authenticationValid();
+
+        if(albumId != 0 &&
+                !memberFindGradeByAlbumIdAndUserIdRepo.findMemberGradeByAlbumIdAndUserId(albumId, user.getId())
+                        .getRules().equals(MemberAlbumGrade.ROLE_ALBUM_ADMIN))
+        {
             throw new NotAlbumAdminException();
         }
     }

--- a/src/main/java/cord/eoeo/momentwo/album/application/port/out/manager/AlbumS3ImageDeletePort.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/port/out/manager/AlbumS3ImageDeletePort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.album.application.port.out.manager;
+
+public interface AlbumS3ImageDeletePort {
+    void s3ImageDelete(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/CreateAlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/CreateAlbumService.java
@@ -48,8 +48,10 @@ public class CreateAlbumService implements CreateAlbumUseCase {
 
         // 앨범에 초대된 멤버 권한 부여
         albumCreateRequestDto.getDoInviteNicknameList().forEach(nickname -> {
-            User inviteUser = userNicknameValidPort.userNicknameValid(nickname);
-            albumAddMemberPort.albumAddMember(newAlbum, inviteUser);
+            if(!admin.getNickname().equals(nickname)) {
+                User inviteUser = userNicknameValidPort.userNicknameValid(nickname);
+                albumAddMemberPort.albumAddMember(newAlbum, inviteUser);
+            }
         });
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/DeleteAlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/DeleteAlbumService.java
@@ -2,9 +2,11 @@ package cord.eoeo.momentwo.album.application.service;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumDeleteRequestDto;
 import cord.eoeo.momentwo.album.advice.exception.NotDeleteAlbumException;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.DeleteAlbumUseCase;
 import cord.eoeo.momentwo.album.application.port.out.AlbumGenericRepo;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberInfoPort;
+import cord.eoeo.momentwo.album.application.port.out.manager.AlbumS3ImageDeletePort;
 import cord.eoeo.momentwo.member.application.port.out.info.IsCheckAlbumAdminPort;
 import cord.eoeo.momentwo.member.application.port.out.info.IsCheckAlbumOneMemberPort;
 import cord.eoeo.momentwo.member.domain.Member;
@@ -19,9 +21,11 @@ public class DeleteAlbumService implements DeleteAlbumUseCase {
     private final IsCheckAlbumOneMemberPort isCheckAlbumOneMemberPort;
     private final GetAlbumMemberInfoPort getAlbumMemberInfoPort;
     private final AlbumGenericRepo albumGenericRepo;
+    private final AlbumS3ImageDeletePort albumS3ImageDeletePort;
 
     @Transactional
     @Override
+    @CheckAlbumAdmin
     public void deleteAlbums(AlbumDeleteRequestDto albumDeleteRequestDto) {
         Member member = getAlbumMemberInfoPort.getMemberInfo(albumDeleteRequestDto.getAlbumId());
         // 관리자이면서 앨범 속 멤버가 한명 이상인 경우 예외
@@ -29,6 +33,11 @@ public class DeleteAlbumService implements DeleteAlbumUseCase {
                 && !isCheckAlbumOneMemberPort.isCheckAlbumOneMember(albumDeleteRequestDto.getAlbumId())) {
             throw new NotDeleteAlbumException();
         }
+
+        // S3 저장소에 있는 사진 삭제
+        albumS3ImageDeletePort.s3ImageDelete(albumDeleteRequestDto.getAlbumId());
+
+        // 앨범에 연관된 데이터 다 삭제
         albumGenericRepo.deleteById(member.getAlbum().getId());
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/EditAlbumTitleService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/EditAlbumTitleService.java
@@ -1,10 +1,10 @@
 package cord.eoeo.momentwo.album.application.service;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumTitleEditRequestDto;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.EditAlbumTitleUseCase;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberInfoPort;
 import cord.eoeo.momentwo.album.application.port.out.manager.AlbumEditPort;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +16,7 @@ public class EditAlbumTitleService implements EditAlbumTitleUseCase {
     private final GetAlbumMemberInfoPort getAlbumMemberInfoPort;
 
     @Transactional
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     @Override
     public void editAlbumsTitle(AlbumTitleEditRequestDto albumTitleEditRequestDto) {
         albumEditPort.albumEdit(

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/profile/AlbumSubTitleDeleteService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/profile/AlbumSubTitleDeleteService.java
@@ -1,10 +1,10 @@
 package cord.eoeo.momentwo.album.application.service.profile;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileRequestDto;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.profile.AlbumSubTitleDeleteUseCase;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberPort;
 import cord.eoeo.momentwo.album.application.port.out.profile.AlbumSubTitleDeletePort;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ public class AlbumSubTitleDeleteService implements AlbumSubTitleDeleteUseCase {
 
     @Override
     @Transactional
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     public void albumSubTitleDelete(AlbumProfileRequestDto albumProfileRequestDto) {
         albumSubTitleDeletePort.albumSubTitleDelete(getAlbumMemberPort.getMember(albumProfileRequestDto.getAlbumId()));
     }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/profile/AlbumSubTitleEditService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/profile/AlbumSubTitleEditService.java
@@ -1,10 +1,10 @@
 package cord.eoeo.momentwo.album.application.service.profile;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumSubTitleEditRequestDto;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.profile.AlbumSubTitleEditUseCase;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberPort;
 import cord.eoeo.momentwo.album.application.port.out.profile.AlbumSubTitleEditPort;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ public class AlbumSubTitleEditService implements AlbumSubTitleEditUseCase {
 
     @Override
     @Transactional
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     public void albumSubTitleEdit(AlbumSubTitleEditRequestDto subTitleEditRequestDto) {
         albumSubTitleEditPort.albumSubTitleEdit(
                 getAlbumMemberPort.getMember(subTitleEditRequestDto.getAlbumId()),

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/profile/ProfileDeleteService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/profile/ProfileDeleteService.java
@@ -1,10 +1,10 @@
 package cord.eoeo.momentwo.album.application.service.profile;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileRequestDto;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.profile.ProfileDeleteUseCase;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberPort;
 import cord.eoeo.momentwo.album.application.port.out.profile.ProfileDeletePort;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ public class ProfileDeleteService implements ProfileDeleteUseCase {
 
     @Override
     @Transactional
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     public void profileDelete(AlbumProfileRequestDto albumProfileRequestDto) {
         profileDeletePort.profileDelete(getAlbumMemberPort.getMember(albumProfileRequestDto.getAlbumId()));
     }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/profile/ProfileUploadService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/profile/ProfileUploadService.java
@@ -2,10 +2,10 @@ package cord.eoeo.momentwo.album.application.service.profile;
 
 import cord.eoeo.momentwo.album.adapter.dto.AlbumProfileUploadRequestDto;
 import cord.eoeo.momentwo.album.adapter.out.profile.ProfileUploadAdapter;
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.in.profile.ProfileUploadUseCase;
 import cord.eoeo.momentwo.album.application.port.out.GetAlbumMemberPort;
 import cord.eoeo.momentwo.config.s3.S3Manager;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +19,7 @@ public class ProfileUploadService implements ProfileUploadUseCase {
 
     @Override
     @Transactional
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     public void profileUpload(AlbumProfileUploadRequestDto uploadRequestDto) {
         profileUploadAdapter.profileUpload(
                 getAlbumMemberPort.getMember(uploadRequestDto.getAlbumId()),

--- a/src/main/java/cord/eoeo/momentwo/image/adapter/out/ImageListDeleteAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/image/adapter/out/ImageListDeleteAdapter.java
@@ -1,0 +1,42 @@
+package cord.eoeo.momentwo.image.adapter.out;
+
+import cord.eoeo.momentwo.config.s3.S3Manager;
+import cord.eoeo.momentwo.image.application.port.out.ImageListDeletePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ImageListDeleteAdapter implements ImageListDeletePort {
+    private final S3Manager s3Manager;
+    private final S3Client s3Client;
+
+    @Override
+    public void imageListDelete(List<String> keys) {
+        // ObjectIdentifier 리스트 생성
+        List<ObjectIdentifier> objectIdentifiers = keys.stream()
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .collect(Collectors.toList());
+
+        // Delete 객체 생성
+        Delete delete = Delete.builder()
+                .objects(objectIdentifiers) // 삭제할 key 리스트 설정
+                .build();
+
+        // S3 삭제 요청
+        DeleteObjectsRequest deleteRequest = DeleteObjectsRequest.builder()
+                .bucket(s3Manager.getBucketName())
+                .delete(delete) // 삭제할 요청 리스트 (최대 1000개)
+                .build();
+
+        // 객체 삭제
+        s3Client.deleteObjects(deleteRequest);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/image/application/port/out/ImageListDeletePort.java
+++ b/src/main/java/cord/eoeo/momentwo/image/application/port/out/ImageListDeletePort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.image.application.port.out;
+
+import java.util.List;
+
+public interface ImageListDeletePort {
+    void imageListDelete(List<String> keys);
+}

--- a/src/main/java/cord/eoeo/momentwo/image/application/service/AlbumProfilePresignedUrlService.java
+++ b/src/main/java/cord/eoeo/momentwo/image/application/service/AlbumProfilePresignedUrlService.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.image.application.service;
 
+import cord.eoeo.momentwo.album.application.aop.annotation.CheckAlbumAdmin;
 import cord.eoeo.momentwo.album.application.port.out.manager.GetAlbumInfoPort;
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.config.s3.S3Manager;
@@ -8,7 +9,6 @@ import cord.eoeo.momentwo.image.adapter.dto.PresignedResponseDto;
 import cord.eoeo.momentwo.image.application.port.in.AlbumProfilePresignedUrlUseCase;
 import cord.eoeo.momentwo.image.application.port.out.ImageDeletePort;
 import cord.eoeo.momentwo.image.application.port.out.MakeImagePresignedUrlPort;
-import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +21,7 @@ public class AlbumProfilePresignedUrlService implements AlbumProfilePresignedUrl
     private final S3Manager s3Manager;
 
     @Override
-    @CheckAlbumAccessRules
+    @CheckAlbumAdmin
     public PresignedResponseDto albumProfilePresignedUrl(PresignedRequestDto presignedRequestDto) {
         Album album = getAlbumInfoPort.getAlbumInfo(presignedRequestDto.getAlbumId());
 

--- a/src/main/java/cord/eoeo/momentwo/photo/adapter/dto/PhotoDeleteRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/adapter/dto/PhotoDeleteRequestDto.java
@@ -13,5 +13,5 @@ public class PhotoDeleteRequestDto {
     private long albumId;
     private long subAlbumId;
     private List<Long> imagesId;
-    private List<String> imagesUrl;
+    private List<String> imagesFilename;
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/adapter/out/find/PhotoFindAllImageAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/adapter/out/find/PhotoFindAllImageAdapter.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.photo.adapter.out.find;
+
+import cord.eoeo.momentwo.photo.application.port.out.find.PhotoFindAllImagePort;
+import cord.eoeo.momentwo.photo.application.port.out.jpa.PhotoFindJpaRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoFindAllImageAdapter implements PhotoFindAllImagePort {
+    private final PhotoFindJpaRepo photoFindJpaRepo;
+
+    @Override
+    public List<String> photoFindAllImage(long albumId) {
+        return photoFindJpaRepo.findAllNameByAlbumId(albumId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/find/PhotoFindAllImagePort.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/find/PhotoFindAllImagePort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.photo.application.port.out.find;
+
+import java.util.List;
+
+public interface PhotoFindAllImagePort {
+    List<String> photoFindAllImage(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/photo/application/port/out/jpa/PhotoFindJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/port/out/jpa/PhotoFindJpaRepo.java
@@ -5,9 +5,13 @@ import cord.eoeo.momentwo.photo.domain.Photo;
 import cord.eoeo.momentwo.user.domain.User;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PhotoFindJpaRepo extends PhotoGenericJpaRepo {
     @Query("SELECT p FROM Photo p WHERE p.id = :id AND p.user = :user")
     Optional<Photo> findByIdAndUser(long id, User user);
+
+    @Query("SELECT p.imageName FROM Photo p WHERE p.album.id = :albumId")
+    List<String> findAllNameByAlbumId(long albumId);
 }


### PR DESCRIPTION
### 앨범 RUD 작업에서 어드민만 가능하도록 수정
- 앨범 삭제 시 저장소 사진 처리방법 고민 -> S3 bulk 지원 사용
- 이미지를 최대 천개까지 한 번에 삭제 가능하도록 설계 (추후 1000개 이상이 될 것을 고려해 1000개 크기로 나누도록 설정)
- 수정 (타이틀, 서브타이틀, 프로필 이미지)
- 삭제 (타이틀, 서브타이틀, 프로필 이미지, 앨범 삭제)
- 프리사인드 url 요청

### 이 외
- 이미지 삭제 요청 DTO 수정 (Url -> Filename)

Resolve: #256 