### PR TITLE
앨범 조회 시 앨범 갯수 반환 추가

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoListResponseDto.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.album.adapter.dto;
 
 import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.photo.application.port.out.get.PhotoGetAlbumCountPort;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,9 +15,10 @@ import java.util.stream.Collectors;
 public class AlbumInfoListResponseDto {
     private List<AlbumInfoResponseDto> albumInfoList;
 
-    public AlbumInfoListResponseDto toDo(List<Album> albums) {
+    public AlbumInfoListResponseDto toDo(List<Album> albums, PhotoGetAlbumCountPort photoGetAlbumCountPort) {
         return new AlbumInfoListResponseDto(
-                albums.stream().map(album -> new AlbumInfoResponseDto().toDo(album))
+                albums.stream().map(album -> new AlbumInfoResponseDto()
+                                .toDo(album, photoGetAlbumCountPort.getAlbumCount(album)))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/album/adapter/dto/AlbumInfoResponseDto.java
@@ -13,13 +13,15 @@ public class AlbumInfoResponseDto {
     private String title;
     private String subTitle;
     private String profileImage;
+    private long albumCount;
 
-    public AlbumInfoResponseDto toDo(Album album) {
+    public AlbumInfoResponseDto toDo(Album album, long albumCount) {
         return new AlbumInfoResponseDto(
                 album.getId(),
                 album.getTitle(),
                 album.getSubTitle(),
-                album.getProfileFilename()
+                album.getProfileFilename(),
+                albumCount
         );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/album/application/service/GetAlbumService.java
+++ b/src/main/java/cord/eoeo/momentwo/album/application/service/GetAlbumService.java
@@ -5,6 +5,7 @@ import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import cord.eoeo.momentwo.album.application.port.in.GetAlbumUseCase;
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.member.application.port.out.find.MemberFindAlbumByUserRepo;
+import cord.eoeo.momentwo.photo.application.port.out.get.PhotoGetAlbumCountPort;
 import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
 import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
@@ -19,6 +20,7 @@ import java.util.List;
 public class GetAlbumService implements GetAlbumUseCase {
     private final MemberFindAlbumByUserRepo memberFindAlbumByUserRepo;
     private final UserNicknameValidPort userNicknameValidPort;
+    private final PhotoGetAlbumCountPort photoGetAlbumCountPort;
 
     @Override
     @CheckAlbumAccessRules
@@ -30,6 +32,7 @@ public class GetAlbumService implements GetAlbumUseCase {
         if(albums.isEmpty()) {
             throw new NotFoundAlbumException();
         }
-        return new AlbumInfoListResponseDto().toDo(albums);
+
+        return new AlbumInfoListResponseDto().toDo(albums, photoGetAlbumCountPort);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoDeleteService.java
+++ b/src/main/java/cord/eoeo/momentwo/photo/application/service/PhotoDeleteService.java
@@ -22,7 +22,7 @@ public class PhotoDeleteService implements PhotoDeleteUseCase {
     @Transactional
     @CheckAlbumAccessRules
     public void photoDelete(PhotoDeleteRequestDto photoDeleteRequestDto) {
-        if(photoDeleteRequestDto.getImagesId().isEmpty() || photoDeleteRequestDto.getImagesUrl().isEmpty()) {
+        if(photoDeleteRequestDto.getImagesId().isEmpty() || photoDeleteRequestDto.getImagesFilename().isEmpty()) {
             throw new NotDeleteImageException();
         }
 
@@ -33,7 +33,7 @@ public class PhotoDeleteService implements PhotoDeleteUseCase {
         );
 
         // 이미지 저장소 삭제
-        photoDeleteRequestDto.getImagesUrl().forEach(image -> {
+        photoDeleteRequestDto.getImagesFilename().forEach(image -> {
             imageDeletePort.imageDelete(s3Manager.getImagePath() + image).join();
         });
     }


### PR DESCRIPTION
### 앨범 조회 시 앨범 갯수 반환 추가
- 앨범 조회 시 앨범 당 담아놓은 사진 갯수를 반환
- 앨범 당 천장의 사진만 보관할 수 있기 때문에 사용자가 알 권리가 있음.

### fix
- 이전 머지 #256 누락 코드 수정

Resolve: #255 