### PR TITLE
관리자 댓글 관리 기능 추가

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentDeleteAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/CommentDeleteAdapter.java
@@ -4,6 +4,7 @@ import cord.eoeo.momentwo.comment.advice.exception.NotCommentAccessException;
 import cord.eoeo.momentwo.comment.application.port.out.CommentGenericRepo;
 import cord.eoeo.momentwo.comment.application.port.out.find.CommentFindIdAndUserRepo;
 import cord.eoeo.momentwo.comment.application.port.out.manager.CommentDeletePort;
+import cord.eoeo.momentwo.comment.application.port.out.manager.IsAdminCompPort;
 import cord.eoeo.momentwo.user.application.port.out.valid.UserNicknameValidPort;
 import cord.eoeo.momentwo.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +16,20 @@ public class CommentDeleteAdapter implements CommentDeletePort {
     private final UserNicknameValidPort userNicknameValidPort;
     private final CommentFindIdAndUserRepo commentFindIdAndUserRepo;
     private final CommentGenericRepo commentGenericRepo;
+    private final IsAdminCompPort isAdminCompPort;
 
     @Override
-    public void commentDelete(long commentId) {
+    public void commentDelete(long albumId, long commentId) {
         User user = userNicknameValidPort.authenticationValid();
-        commentFindIdAndUserRepo.findByIdAndUser(commentId, user).orElseThrow(NotCommentAccessException::new);
+        commentFindIdAndUserRepo.findByIdAndUser(commentId, user).ifPresentOrElse(
+                comment -> {
+                },
+                () -> {
+                    if(!isAdminCompPort.isAdmin(albumId, commentId, user)) {
+                        throw new NotCommentAccessException();
+                    }
+                }
+        );
         commentGenericRepo.deleteById(commentId);
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/IsAdminCompAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/adapter/out/manager/IsAdminCompAdapter.java
@@ -1,0 +1,28 @@
+package cord.eoeo.momentwo.comment.adapter.out.manager;
+
+import cord.eoeo.momentwo.comment.advice.exception.NotFoundCommentException;
+import cord.eoeo.momentwo.comment.application.port.out.CommentGenericRepo;
+import cord.eoeo.momentwo.comment.application.port.out.manager.IsAdminCompPort;
+import cord.eoeo.momentwo.comment.domain.Comment;
+import cord.eoeo.momentwo.member.application.port.out.find.MemberFindGradeByAlbumIdAndUserIdRepo;
+import cord.eoeo.momentwo.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IsAdminCompAdapter implements IsAdminCompPort {
+    private final MemberFindGradeByAlbumIdAndUserIdRepo memberFindGradeByAlbumIdAndUserIdRepo;
+    private final CommentGenericRepo commentGenericRepo;
+
+    @Override
+    public boolean isAdmin(long albumId, long commentId, User user) {
+        Comment comment = commentGenericRepo.findById(commentId).orElseThrow(NotFoundCommentException::new);
+        int inputUserPriority = memberFindGradeByAlbumIdAndUserIdRepo
+                .findMemberGradeByAlbumIdAndUserId(albumId, user.getId()).getRules().getPriority();
+        int commentUserPriority = memberFindGradeByAlbumIdAndUserIdRepo
+                .findMemberGradeByAlbumIdAndUserId(albumId, comment.getUser().getId()).getRules().getPriority();
+
+        return inputUserPriority < commentUserPriority; // 우선순위 : 관리자 1, 부관리자 2
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/manager/CommentDeletePort.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/manager/CommentDeletePort.java
@@ -1,5 +1,5 @@
 package cord.eoeo.momentwo.comment.application.port.out.manager;
 
 public interface CommentDeletePort {
-    void commentDelete(long commentId);
+    void commentDelete(long albumId, long commentId);
 }

--- a/src/main/java/cord/eoeo/momentwo/comment/application/port/out/manager/IsAdminCompPort.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/port/out/manager/IsAdminCompPort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.comment.application.port.out.manager;
+
+import cord.eoeo.momentwo.user.domain.User;
+
+public interface IsAdminCompPort {
+    boolean isAdmin(long albumId, long commentId, User user);
+}

--- a/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentDeleteService.java
+++ b/src/main/java/cord/eoeo/momentwo/comment/application/service/CommentDeleteService.java
@@ -17,6 +17,9 @@ public class CommentDeleteService implements DeleteCommentUseCase {
     @CheckAlbumAccessRules
     @Transactional
     public void deleteComment(CommentDeleteRequestDto commentDeleteRequestDto) {
-        commentDeletePort.commentDelete(commentDeleteRequestDto.getCommentId());
+        commentDeletePort.commentDelete(
+                commentDeleteRequestDto.getAlbumId(),
+                commentDeleteRequestDto.getCommentId()
+        );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/member/adapter/in/EditMembersGradeController.java
+++ b/src/main/java/cord/eoeo/momentwo/member/adapter/in/EditMembersGradeController.java
@@ -14,7 +14,7 @@ import javax.validation.Valid;
 @RestController
 @RequiredArgsConstructor
 public class EditMembersGradeController {
-    private EditMembersGradeUseCase editMembersGradeUseCase;
+    private final EditMembersGradeUseCase editMembersGradeUseCase;
 
     // 멤버 권한 변경 (앨범 수정 권한)
     @PutMapping("/members/permission")


### PR DESCRIPTION
### 관리자 댓글 관리 기능 추가
- 관리자는 모든 멤버의 댓글을 삭제할 수 있다.
- 관리자는 부관리자의 댓글도 삭제할 수 있다.
- 부관리자는 일반 멤버의 댓글만 삭제할 수 있다.
- 부관리자는 부관리자의 댓글을 삭제할 수 없다.

### fix
- 권한 편집 final 누락 수정

Resolve: #266