### PR TITLE
태그 적용 구현

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/TagSearchRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/TagSearchRequestDto.java
@@ -1,0 +1,12 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagSearchRequestDto {
+    private long albumId;
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/TagSearchResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/TagSearchResponseDto.java
@@ -1,0 +1,23 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out;
+
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagSearchResponseDto {
+    private long id;
+    private List<String> albumTags;
+
+    public TagSearchResponseDto toDo(TagsDocument tagsDocument) {
+        return new TagSearchResponseDto(
+                this.id = tagsDocument.getAlbumId(),
+                this.albumTags = tagsDocument.getAlbumTagsTerms()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/TagSearchController.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/TagSearchController.java
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.in;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.TagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.TagSearchResponseDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.in.TagSearchUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class TagSearchController {
+    private final TagSearchUseCase tagSearchUseCase;
+
+    @GetMapping("/albums/tags/search")
+    @ResponseStatus(HttpStatus.OK)
+    public TagSearchResponseDto getAlbumTags(@ModelAttribute @Valid TagSearchRequestDto tagSearchRequestDto) {
+        return tagSearchUseCase.getAlbumTags(tagSearchRequestDto);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/TagsElasticsearchAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/TagsElasticsearchAdapter.java
@@ -1,0 +1,30 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag;
+
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.TagsElasticsearchErRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.TagsElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TagsElasticsearchAdapter implements TagsElasticsearchRepo {
+    private final TagsElasticsearchErRepo tagsElasticsearchErRepo;
+
+    @Override
+    public void save(TagsDocument entity) {
+        tagsElasticsearchErRepo.save(entity);
+    }
+
+    @Override
+    public Optional<TagsDocument> findById(String id) {
+        return tagsElasticsearchErRepo.findById(id);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        tagsElasticsearchErRepo.deleteById(id);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/manager/AlbumTagsSaveAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/manager/AlbumTagsSaveAdapter.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.manager;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.TagsElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.manager.AlbumTagsSavePort;
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagsSaveAdapter implements AlbumTagsSavePort {
+    private final TagsElasticsearchRepo tagsElasticsearchRepo;
+
+    @Override
+    public void albumTagsSave(Album album, List<String> albumTags) {
+        TagsDocument tagsDocument = new TagsDocument(album, albumTags);
+        tagsElasticsearchRepo.save(tagsDocument);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/manager/GetAlbumTagsAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/manager/GetAlbumTagsAdapter.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.manager;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.TagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.advice.tag.exception.NotFoundAlbumTagsException;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.TagsElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.manager.GetAlbumTagsPort;
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetAlbumTagsAdapter implements GetAlbumTagsPort {
+    private final TagsElasticsearchRepo tagsElasticsearchRepo;
+
+    @Override
+    public TagsDocument getAlbumTags(TagSearchRequestDto tagSearchRequestDto) {
+        return tagsElasticsearchRepo.findById("tags_" + tagSearchRequestDto.getAlbumId())
+                .orElseThrow(NotFoundAlbumTagsException::new);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/TagsExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/TagsExceptionHandler.java
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.elasticsearch.advice.tag;
+
+import cord.eoeo.momentwo.elasticsearch.advice.tag.exception.NotFoundAlbumTagsException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class TagsExceptionHandler {
+    @ExceptionHandler(NotFoundAlbumTagsException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String notFoundAlbumTagsException() {
+        return "앨범에 지정한 태그가 없습니다.";
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/exception/NotFoundAlbumTagsException.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/exception/NotFoundAlbumTagsException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.elasticsearch.advice.tag.exception;
+
+public class NotFoundAlbumTagsException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/TagSearchUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/TagSearchUseCase.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.in;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.TagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.TagSearchResponseDto;
+
+public interface TagSearchUseCase {
+    TagSearchResponseDto getAlbumTags(TagSearchRequestDto tagSearchRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/TagsElasticsearchErRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/TagsElasticsearchErRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag;
+
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultJpaRepo;
+
+public interface TagsElasticsearchErRepo extends ElasticsearchGenericDefaultJpaRepo<TagsDocument, String> {
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/TagsElasticsearchRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/TagsElasticsearchRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag;
+
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultRepo;
+
+public interface TagsElasticsearchRepo extends ElasticsearchGenericDefaultRepo<TagsDocument, String> {
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/manager/AlbumTagsSavePort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/manager/AlbumTagsSavePort.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.manager;
+
+import cord.eoeo.momentwo.album.domain.Album;
+
+import java.util.List;
+
+public interface AlbumTagsSavePort {
+    void albumTagsSave(Album album, List<String> albumTags);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/manager/GetAlbumTagsPort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/manager/GetAlbumTagsPort.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.manager;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.TagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.domain.TagsDocument;
+
+public interface GetAlbumTagsPort {
+    TagsDocument getAlbumTags(TagSearchRequestDto tagSearchRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/TagSearchService.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/TagSearchService.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.elasticsearch.application.service;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.TagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.TagSearchResponseDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.in.TagSearchUseCase;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.manager.GetAlbumTagsPort;
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TagSearchService implements TagSearchUseCase {
+    private final GetAlbumTagsPort getAlbumTagsPort;
+
+    @Override
+    @CheckAlbumAccessRules
+    public TagSearchResponseDto getAlbumTags(TagSearchRequestDto tagSearchRequestDto) {
+        return new TagSearchResponseDto().toDo(getAlbumTagsPort.getAlbumTags(tagSearchRequestDto));
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/TagsDocument.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/TagsDocument.java
@@ -1,0 +1,52 @@
+package cord.eoeo.momentwo.elasticsearch.domain;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import javax.persistence.Id;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "tags")
+public class TagsDocument {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private long albumId;
+
+    /**
+     * 부분 검색
+     * analyzer : 리스트 값을 하나의 토큰화하여 저장
+     * ex) 저장된 데이터 "새로운", "여행"
+     * 검색 시 "새로운 " or "새로운 여정"
+     * 새로운이라는 단어가 포함된 것을 조회
+     * 사용 : match
+     */
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private List<String> albumTagsMatches;
+
+    /**
+     * 정확한 일치 데이터 검색
+     * ex) 저장된 데이터 "새로운", "여행"
+     * 검색 시 ["새로운"] or ["새로운", "여행"]
+     * 문자열안에 딱 해당 단어가 포함된 것만 조회
+     * 사용 : terms
+     */
+    @Field(type = FieldType.Keyword)
+    private List<String> albumTagsTerms;
+
+    public TagsDocument(Album album, List<String> albumTags) {
+        this.id = "tags_" + album.getId();
+        this.albumId = album.getId();
+        this.albumTagsMatches = albumTags;
+        this.albumTagsTerms = albumTags;
+    }
+}


### PR DESCRIPTION
### 태그 적용 구현
- 각 앨범 기준 태그를 20개 정할 수 있도록 할당하고, 태그 기준 정리할 수 있도록 함
- 태그는 태그+앨범명으로 문서화

Resolve: #270 