### PR TITLE
사진 태그 검색 구현

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/description/adapter/dto/out/DescriptionResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/description/adapter/dto/out/DescriptionResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -15,13 +16,15 @@ public class DescriptionResponseDto {
     private String userProfileImage;
     private String description;
     private LocalDate date;
+    private List<String> photoTags;
 
-    public DescriptionResponseDto toDo(Description description) {
+    public DescriptionResponseDto toDo(Description description, List<String> photoTags) {
         return new DescriptionResponseDto(
                 description.getPhoto().getUser().getNickname(),
                 description.getPhoto().getUser().getUserProfileImage(),
                 description.getDescription(),
-                description.getDate()
+                description.getDate(),
+                photoTags
         );
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/description/adapter/out/manager/DescriptionGetAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/description/adapter/out/manager/DescriptionGetAdapter.java
@@ -5,17 +5,23 @@ import cord.eoeo.momentwo.description.advice.exception.NotFoundDescriptionExcept
 import cord.eoeo.momentwo.description.application.port.out.find.DescriptionFindByPhotoRepo;
 import cord.eoeo.momentwo.description.application.port.out.manager.DescriptionGetPort;
 import cord.eoeo.momentwo.description.domain.Description;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.IsPhotoTagPort;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagGetPort;
 import cord.eoeo.momentwo.photo.advice.exception.NotFoundPhotoException;
 import cord.eoeo.momentwo.photo.application.port.out.PhotoGenericRepo;
 import cord.eoeo.momentwo.photo.domain.Photo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class DescriptionGetAdapter implements DescriptionGetPort {
     private final PhotoGenericRepo photoGenericRepo;
     private final DescriptionFindByPhotoRepo descriptionFindByPhotoRepo;
+    private final PhotoTagGetPort photoTagGetPort;
+    private final IsPhotoTagPort isPhotoTagPort;
 
     @Override
     public DescriptionResponseDto getDescription(long photoId) {
@@ -24,6 +30,10 @@ public class DescriptionGetAdapter implements DescriptionGetPort {
         Description description = descriptionFindByPhotoRepo.findByPhoto(photo)
                 .orElseThrow(NotFoundDescriptionException::new);
 
-        return new DescriptionResponseDto().toDo(description);
+        if(isPhotoTagPort.isPhotoTag(photoId)) {
+            return new DescriptionResponseDto().toDo(description, photoTagGetPort.photoTagGet(photoId).getPhotoTags());
+        }
+
+        return new DescriptionResponseDto().toDo(description, List.of());
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/photo/PhotoTagSearchRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/in/photo/PhotoTagSearchRequestDto.java
@@ -1,0 +1,18 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagSearchRequestDto {
+    private long albumId;
+    private long photoId;
+    private List<String> photoTags;
+    private int page;
+    private int size;
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagGetResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagGetResponseDto.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo;
+
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagGetResponseDto {
+    private List<String> photoTags;
+
+    public PhotoTagGetResponseDto toDo(PhotoTagsDocument photoTagsDocument) {
+        return new PhotoTagGetResponseDto(
+                photoTagsDocument.getPhotoTagsTerms()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagSearchListResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagSearchListResponseDto.java
@@ -1,0 +1,36 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo;
+
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagSearchListResponseDto {
+    private List<PhotoTagSearchResponseDto> photoTagsSearch;
+    private long page;
+    private long size;
+    private long totalPages;
+    private long totalElements;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public PhotoTagSearchListResponseDto toDo(Page<PhotoTagsDocument> photoTagsDocuments) {
+        return new PhotoTagSearchListResponseDto(
+                photoTagsDocuments.stream().map(photoTagsDocument -> new PhotoTagSearchResponseDto()
+                        .toDo(photoTagsDocument)).collect(Collectors.toList()),
+                photoTagsDocuments.getNumber(),
+                photoTagsDocuments.getSize(),
+                photoTagsDocuments.getTotalPages(),
+                photoTagsDocuments.getTotalElements(),
+                photoTagsDocuments.hasNext(),
+                photoTagsDocuments.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagSearchResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/dto/out/photo/PhotoTagSearchResponseDto.java
@@ -1,0 +1,27 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo;
+
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagSearchResponseDto {
+    private long albumId;
+    private long photoId;
+    private String imageUrl;
+    private List<String> photoTags;
+
+    public PhotoTagSearchResponseDto toDo(PhotoTagsDocument photoTagsDocument) {
+        return new PhotoTagSearchResponseDto(
+                this.albumId = photoTagsDocument.getAlbumId(),
+                this.photoId = photoTagsDocument.getPhotoId(),
+                this.imageUrl = photoTagsDocument.getImageUrl(),
+                this.photoTags = photoTagsDocument.getPhotoTagsTerms()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/PhotoTagSearchController.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/in/PhotoTagSearchController.java
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.in;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo.PhotoTagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo.PhotoTagSearchListResponseDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.in.photo.PhotoTagSearchUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class PhotoTagSearchController {
+    private final PhotoTagSearchUseCase photoTagSearchUseCase;
+
+    @GetMapping("/photos/tags/search")
+    @ResponseStatus(HttpStatus.OK)
+    public PhotoTagSearchListResponseDto photoTagSearch(
+            @ModelAttribute @Valid PhotoTagSearchRequestDto photoTagSearchRequestDto) {
+        return photoTagSearchUseCase.photoTagSearch(photoTagSearchRequestDto);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/like/LikesElasticsearchAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/like/LikesElasticsearchAdapter.java
@@ -21,12 +21,12 @@ public class LikesElasticsearchAdapter implements LikesElasticsearchRepo {
     }
 
     @Override
-    public Optional<LikesDocument> findById(Long id) {
+    public Optional<LikesDocument> findById(String id) {
         return likesElasticsearchErRepo.findById(id);
     }
 
     @Override
-    public void deleteById(Long id) {
+    public void deleteById(String id) {
         likesElasticsearchErRepo.deleteById(id);
     }
 

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/IsPhotoTagAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/IsPhotoTagAdapter.java
@@ -1,0 +1,33 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.IsPhotoTagPort;
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IsPhotoTagAdapter implements IsPhotoTagPort {
+    private final ElasticsearchRestTemplate elasticsearchRestTemplate;
+
+    @Override
+    public boolean isPhotoTag(long photoId) {
+        NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+                .withQuery(QueryBuilders.termQuery("id",  "tags_" + photoId))
+                .build();
+
+        // 검색 결과 가져오기
+        SearchHits<PhotoTagsDocument> searchHit = elasticsearchRestTemplate.search(searchQuery, PhotoTagsDocument.class);
+
+        // 비어있다면 태그 정보 없음
+        if(searchHit.getSearchHits().isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagElasticsearchAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagElasticsearchAdapter.java
@@ -1,0 +1,37 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagCountByAlbumIdRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagElasticsearchErRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagElasticsearchAdapter implements PhotoTagElasticsearchRepo {
+    private final PhotoTagElasticsearchErRepo photoTagElasticsearchErRepo;
+    private final PhotoTagCountByAlbumIdRepo photoTagCountByAlbumIdRepo;
+
+    @Override
+    public long countByAlbumId(long albumId) {
+        return photoTagCountByAlbumIdRepo.countByAlbumId(albumId);
+    }
+
+    @Override
+    public void save(PhotoTagsDocument entity) {
+        photoTagElasticsearchErRepo.save(entity);
+    }
+
+    @Override
+    public Optional<PhotoTagsDocument> findById(String id) {
+        return photoTagElasticsearchErRepo.findById(id);
+    }
+
+    @Override
+    public void deleteById(String id) {
+        photoTagElasticsearchErRepo.deleteById(id);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagGetAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagGetAdapter.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo.PhotoTagGetResponseDto;
+import cord.eoeo.momentwo.elasticsearch.advice.tag.exception.NotFoundPhotoTagInfoException;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagGetPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagGetAdapter implements PhotoTagGetPort {
+    private final PhotoTagElasticsearchRepo photoTagElasticsearchRepo;
+
+    @Override
+    public PhotoTagGetResponseDto photoTagGet(long photoId) {
+        String id = "tags_" + photoId;
+
+        return new PhotoTagGetResponseDto()
+                .toDo(photoTagElasticsearchRepo.findById(id).orElseThrow(NotFoundPhotoTagInfoException::new));
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagSearchAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagSearchAdapter.java
@@ -1,0 +1,52 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo.PhotoTagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagSearchPort;
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagSearchAdapter implements PhotoTagSearchPort {
+    private final ElasticsearchRestTemplate elasticsearchRestTemplate;
+    private final PhotoTagElasticsearchRepo photoTagElasticsearchRepo;
+
+    @Override
+    public Page<PhotoTagsDocument> photoTagSearch(PhotoTagSearchRequestDto photoTagSearchRequestDto, Pageable pageable) {
+        NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+                .withQuery(QueryBuilders.boolQuery()
+                        .must(QueryBuilders.matchQuery("albumId", photoTagSearchRequestDto.getAlbumId()))
+                        .must(QueryBuilders.termsQuery("photoTagsTerms", photoTagSearchRequestDto.getPhotoTags()))
+                )
+                .withPageable(pageable)
+                .build();
+
+        // 검색 결과 가져오기
+        SearchHits<PhotoTagsDocument> searchHit = elasticsearchRestTemplate.search(searchQuery, PhotoTagsDocument.class);
+
+        // 검색된 데이터를 리스트로 변환
+        List<PhotoTagsDocument> photoTagsDocuments = searchHit.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(
+                photoTagsDocuments,
+                pageable,
+                photoTagElasticsearchRepo.countByAlbumId(photoTagSearchRequestDto.getAlbumId())
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagsSaveAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/adpater/out/tag/photo/PhotoTagsSaveAdapter.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.elasticsearch.adpater.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagElasticsearchRepo;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagsSavePort;
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import cord.eoeo.momentwo.photo.domain.Photo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagsSaveAdapter implements PhotoTagsSavePort {
+    private final PhotoTagElasticsearchRepo photoTagElasticsearchRepo;
+
+    @Override
+    public void photoTagsSave(Photo photo, List<String> photoTags) {
+        PhotoTagsDocument photoTagsDocument = new PhotoTagsDocument(photo, photoTags);
+        photoTagElasticsearchRepo.save(photoTagsDocument);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/TagsExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/TagsExceptionHandler.java
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.elasticsearch.advice.tag;
 
 import cord.eoeo.momentwo.elasticsearch.advice.tag.exception.NotFoundAlbumTagsException;
+import cord.eoeo.momentwo.elasticsearch.advice.tag.exception.NotFoundPhotoTagInfoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -11,6 +12,12 @@ public class TagsExceptionHandler {
     @ExceptionHandler(NotFoundAlbumTagsException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String notFoundAlbumTagsException() {
+        return "앨범에 지정한 태그가 없습니다.";
+    }
+
+    @ExceptionHandler(NotFoundPhotoTagInfoException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String notFoundPhotoTagInfoException() {
         return "앨범에 지정한 태그가 없습니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/exception/NotFoundPhotoTagInfoException.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/advice/tag/exception/NotFoundPhotoTagInfoException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.elasticsearch.advice.tag.exception;
+
+public class NotFoundPhotoTagInfoException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/photo/PhotoTagSearchUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/in/photo/PhotoTagSearchUseCase.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.in.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo.PhotoTagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo.PhotoTagSearchListResponseDto;
+
+public interface PhotoTagSearchUseCase {
+    PhotoTagSearchListResponseDto photoTagSearch(PhotoTagSearchRequestDto photoTagSearchRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/like/LikesElasticsearchErRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/like/LikesElasticsearchErRepo.java
@@ -3,5 +3,5 @@ package cord.eoeo.momentwo.elasticsearch.application.port.out.like;
 import cord.eoeo.momentwo.elasticsearch.domain.LikesDocument;
 import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultJpaRepo;
 
-public interface LikesElasticsearchErRepo extends ElasticsearchGenericDefaultJpaRepo<LikesDocument, Long> {
+public interface LikesElasticsearchErRepo extends ElasticsearchGenericDefaultJpaRepo<LikesDocument, String> {
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/like/LikesElasticsearchRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/like/LikesElasticsearchRepo.java
@@ -3,6 +3,6 @@ package cord.eoeo.momentwo.elasticsearch.application.port.out.like;
 import cord.eoeo.momentwo.elasticsearch.domain.LikesDocument;
 import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultRepo;
 
-public interface LikesElasticsearchRepo extends ElasticsearchGenericDefaultRepo<LikesDocument, Long> {
+public interface LikesElasticsearchRepo extends ElasticsearchGenericDefaultRepo<LikesDocument, String> {
     long countByPhotoId(long photoId);
 }

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/IsPhotoTagPort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/IsPhotoTagPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+public interface IsPhotoTagPort {
+    boolean isPhotoTag(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagCountByAlbumIdRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagCountByAlbumIdRepo.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+public interface PhotoTagCountByAlbumIdRepo extends PhotoTagElasticsearchErRepo {
+    long countByAlbumId(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagElasticsearchErRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagElasticsearchErRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultJpaRepo;
+
+public interface PhotoTagElasticsearchErRepo extends ElasticsearchGenericDefaultJpaRepo<PhotoTagsDocument, String> {
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagElasticsearchRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagElasticsearchRepo.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import cord.eoeo.momentwo.global.application.port.out.ElasticsearchGenericDefaultRepo;
+
+public interface PhotoTagElasticsearchRepo extends ElasticsearchGenericDefaultRepo<PhotoTagsDocument, String> {
+    long countByAlbumId(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagGetPort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagGetPort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo.PhotoTagGetResponseDto;
+
+public interface PhotoTagGetPort {
+    PhotoTagGetResponseDto photoTagGet(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagSearchPort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagSearchPort.java
@@ -1,0 +1,10 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo.PhotoTagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.domain.PhotoTagsDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PhotoTagSearchPort {
+    Page<PhotoTagsDocument> photoTagSearch(PhotoTagSearchRequestDto photoTagSearchRequestDto, Pageable pageable);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagsSavePort.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/port/out/tag/photo/PhotoTagsSavePort.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo;
+
+import cord.eoeo.momentwo.photo.domain.Photo;
+
+import java.util.List;
+
+public interface PhotoTagsSavePort {
+    void photoTagsSave(Photo photo, List<String> photoTags);
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/photo/PhotoTagSearchService.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/application/service/photo/PhotoTagSearchService.java
@@ -1,0 +1,27 @@
+package cord.eoeo.momentwo.elasticsearch.application.service.photo;
+
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.in.photo.PhotoTagSearchRequestDto;
+import cord.eoeo.momentwo.elasticsearch.adpater.dto.out.photo.PhotoTagSearchListResponseDto;
+import cord.eoeo.momentwo.elasticsearch.application.port.in.photo.PhotoTagSearchUseCase;
+import cord.eoeo.momentwo.elasticsearch.application.port.out.tag.photo.PhotoTagSearchPort;
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoTagSearchService implements PhotoTagSearchUseCase {
+    private final PhotoTagSearchPort photoTagSearchPort;
+
+    @Override
+    @CheckAlbumAccessRules
+    public PhotoTagSearchListResponseDto photoTagSearch(PhotoTagSearchRequestDto photoTagSearchRequestDto) {
+        return new PhotoTagSearchListResponseDto()
+                .toDo(photoTagSearchPort.photoTagSearch(
+                        photoTagSearchRequestDto,
+                        PageRequest.of(photoTagSearchRequestDto.getPage(), photoTagSearchRequestDto.getSize())
+                    )
+                );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/PhotoTagsDocument.java
+++ b/src/main/java/cord/eoeo/momentwo/elasticsearch/domain/PhotoTagsDocument.java
@@ -1,0 +1,60 @@
+package cord.eoeo.momentwo.elasticsearch.domain;
+
+import cord.eoeo.momentwo.photo.domain.Photo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import javax.persistence.Id;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "photo_tags")
+public class PhotoTagsDocument {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private long albumId;
+
+    @Field(type = FieldType.Long)
+    private long photoId;
+
+    @Field(type = FieldType.Text)
+    private String imageUrl;
+
+    /**
+     * 부분 검색
+     * analyzer : 리스트 값을 하나의 토큰화하여 저장
+     * ex) 저장된 데이터 "새로운", "여행"
+     * 검색 시 "새로운 " or "새로운 여정"
+     * 새로운이라는 단어가 포함된 것을 조회
+     * 사용 : match
+     */
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private List<String> photoTagsMatches;
+
+    /**
+     * 정확한 일치 데이터 검색
+     * ex) 저장된 데이터 "새로운", "여행"
+     * 검색 시 ["새로운"] or ["새로운", "여행"]
+     * 문자열안에 딱 해당 단어가 포함된 것만 조회
+     * 사용 : terms
+     */
+    @Field(type = FieldType.Keyword)
+    private List<String> photoTagsTerms;
+
+    public PhotoTagsDocument(Photo photo, List<String> photoTags) {
+        this.id = "tags_" + photo.getId();
+        this.albumId = photo.getAlbum().getId();
+        this.photoId = photo.getId();
+        this.imageUrl = photo.getImageName();
+        this.photoTagsMatches = photoTags;
+        this.photoTagsTerms = photoTags;
+    }
+}


### PR DESCRIPTION
### 사진 태그 검색 구현
- 각 id는 태그+사진id으로 정의
- 사진 검색 시 태그 검색 구현
- ~~태그 추가 시 기존 태그에 업데이트 하는 방식으로 구현~~

### 태그 조회
- 설명 조회 시 같이 반환

### fix
- 좋아요 레포 Id 타입 수정

Resolve: #271