### PR TITLE
태그 테이블 생성 및 기능 구현

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagCreateRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagCreateRequestDto.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.album;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumTagCreateRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+
+    @NotBlank(message = "태그명 누락")
+    private String tag;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagDeleteRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.album;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumTagDeleteRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+
+    @NotNull(message = "태그 아이디 누락")
+    private Long albumTagId;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagGetRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagGetRequestDto.java
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.album;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumTagGetRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagUpdateRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/album/AlbumTagUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.album;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumTagUpdateRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+
+    @NotNull(message = "앨범 태그 아이디 누락")
+    private Long albumTagId;
+
+    @NotBlank(message = "바꿀 태그 이름 누락")
+    private String editTag;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/photo/PhotoTagAddRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/photo/PhotoTagAddRequestDto.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.photo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagAddRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+
+    @NotNull(message = "사진 아이디 누락")
+    private Long photoId;
+
+    @NotNull(message = "앨범 태그 아이디 누락")
+    private Long albumTagId;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/photo/PhotoTagRemoveRequestDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/in/photo/PhotoTagRemoveRequestDto.java
@@ -1,0 +1,21 @@
+package cord.eoeo.momentwo.tag.adapter.dto.in.photo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PhotoTagRemoveRequestDto {
+    @NotNull(message = "앨범 아이디 누락")
+    private Long albumId;
+
+    @NotNull(message = "사진 아이디 누락")
+    private Long photoId;
+
+    @NotNull(message = "사진 태그 아이디 누락")
+    private Long photoTagId;
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/out/album/AlbumTagGetResponseDto.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/dto/out/album/AlbumTagGetResponseDto.java
@@ -1,0 +1,20 @@
+package cord.eoeo.momentwo.tag.adapter.dto.out.album;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AlbumTagGetResponseDto {
+    private List<String> albumTags;
+
+    public AlbumTagGetResponseDto toDo(List<String> albumTags) {
+        return new AlbumTagGetResponseDto(
+                albumTags
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/AlbumTagGenericAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/AlbumTagGenericAdapter.java
@@ -1,0 +1,36 @@
+package cord.eoeo.momentwo.tag.adapter.out.album;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericJpaRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AlbumTagGenericAdapter implements AlbumTagGenericRepo {
+    private final AlbumTagGenericJpaRepo albumTagGenericJpaRepo;
+
+    @Override
+    public void save(AlbumTag entity) {
+        albumTagGenericJpaRepo.save(entity);
+    }
+
+    @Override
+    public Optional<AlbumTag> findById(Long id) {
+        return albumTagGenericJpaRepo.findById(id);
+    }
+
+    @Override
+    public List<AlbumTag> findAll() {
+        return albumTagGenericJpaRepo.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        albumTagGenericJpaRepo.deleteById(id);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagCountAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagCountAdapter.java
@@ -1,0 +1,17 @@
+package cord.eoeo.momentwo.tag.adapter.out.album.manager;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.jpa.AlbumTagCountRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagCountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagCountAdapter implements AlbumTagCountPort {
+    private final AlbumTagCountRepo albumTagCountRepo;
+
+    @Override
+    public int albumTagCount(long albumId) {
+        return albumTagCountRepo.albumTagCount(albumId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagDeleteAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagDeleteAdapter.java
@@ -1,0 +1,17 @@
+package cord.eoeo.momentwo.tag.adapter.out.album.manager;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagDeletePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagDeleteAdapter implements AlbumTagDeletePort {
+    private final AlbumTagGenericRepo albumTagGenericRepo;
+
+    @Override
+    public void albumTagDelete(long albumTagId) {
+        albumTagGenericRepo.deleteById(albumTagId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagGetAllTagAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagGetAllTagAdapter.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.tag.adapter.out.album.manager;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.jpa.AlbumTagGetJpaRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagGetAllTagPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagGetAllTagAdapter implements AlbumTagGetAllTagPort {
+    private final AlbumTagGetJpaRepo albumTagGetJpaRepo;
+
+    @Override
+    public List<String> allTagByAlbumId(long albumId) {
+        return albumTagGetJpaRepo.allTagByAlbumId(albumId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagSaveAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagSaveAdapter.java
@@ -4,8 +4,10 @@ import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
 import cord.eoeo.momentwo.album.application.port.out.AlbumGenericRepo;
 import cord.eoeo.momentwo.album.domain.Album;
 import cord.eoeo.momentwo.tag.advice.exception.TagDuplicateException;
+import cord.eoeo.momentwo.tag.advice.exception.TagExceedException;
 import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
 import cord.eoeo.momentwo.tag.application.port.out.album.jpa.AlbumTagGetAlbumIdAndTagRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagCountPort;
 import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagSavePort;
 import cord.eoeo.momentwo.tag.domain.AlbumTag;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +19,14 @@ public class AlbumTagSaveAdapter implements AlbumTagSavePort {
     private final AlbumGenericRepo albumGenericRepo;
     private final AlbumTagGenericRepo albumTagGenericRepo;
     private final AlbumTagGetAlbumIdAndTagRepo albumTagGetAlbumIdAndTagRepo;
+    private final AlbumTagCountPort albumTagCountPort;
 
     @Override
     public void albumTagSave(long albumId, String tag) {
+        if(albumTagCountPort.albumTagCount(albumId) >= 20) {
+            throw new TagExceedException();
+        }
+
         // 앨범이 있는지 확인
         Album album = albumGenericRepo.findById(albumId).orElseThrow(NotFoundAlbumException::new);
 

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagSaveAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagSaveAdapter.java
@@ -1,0 +1,36 @@
+package cord.eoeo.momentwo.tag.adapter.out.album.manager;
+
+import cord.eoeo.momentwo.album.advice.exception.NotFoundAlbumException;
+import cord.eoeo.momentwo.album.application.port.out.AlbumGenericRepo;
+import cord.eoeo.momentwo.album.domain.Album;
+import cord.eoeo.momentwo.tag.advice.exception.TagDuplicateException;
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.jpa.AlbumTagGetAlbumIdAndTagRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagSavePort;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagSaveAdapter implements AlbumTagSavePort {
+    private final AlbumGenericRepo albumGenericRepo;
+    private final AlbumTagGenericRepo albumTagGenericRepo;
+    private final AlbumTagGetAlbumIdAndTagRepo albumTagGetAlbumIdAndTagRepo;
+
+    @Override
+    public void albumTagSave(long albumId, String tag) {
+        // 앨범이 있는지 확인
+        Album album = albumGenericRepo.findById(albumId).orElseThrow(NotFoundAlbumException::new);
+
+        // 이미 있는 태그인지 확인
+        albumTagGetAlbumIdAndTagRepo.getAlbumIdAndTag(albumId, tag).ifPresentOrElse(
+                albumTag -> {
+                    throw new TagDuplicateException();
+                },
+                () -> {
+                    albumTagGenericRepo.save(new AlbumTag(album, tag));
+                }
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagUpdateAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/album/manager/AlbumTagUpdateAdapter.java
@@ -1,0 +1,32 @@
+package cord.eoeo.momentwo.tag.adapter.out.album.manager;
+
+import cord.eoeo.momentwo.tag.advice.exception.NotFoundTagException;
+import cord.eoeo.momentwo.tag.advice.exception.TagDuplicateException;
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.jpa.AlbumTagGetAlbumIdAndTagRepo;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagUpdatePort;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumTagUpdateAdapter implements AlbumTagUpdatePort {
+    private final AlbumTagGenericRepo albumTagGenericRepo;
+    private final AlbumTagGetAlbumIdAndTagRepo albumTagGetAlbumIdAndTagRepo;
+
+    @Override
+    public void albumTagUpdate(long albumId, long albumTagId, String tag) {
+        // 이미 있는 태그인지 확인
+        albumTagGetAlbumIdAndTagRepo.getAlbumIdAndTag(albumId, tag).ifPresentOrElse(
+                albumTag -> {
+                    throw new TagDuplicateException();
+                },
+                () -> {
+                    AlbumTag albumTag = albumTagGenericRepo.findById(albumTagId).orElseThrow(NotFoundTagException::new);
+                    albumTag.setTag(tag);
+                    albumTagGenericRepo.save(albumTag);
+                }
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/PhotoTagGenericAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/PhotoTagGenericAdapter.java
@@ -1,0 +1,36 @@
+package cord.eoeo.momentwo.tag.adapter.out.photo;
+
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericJpaRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericRepo;
+import cord.eoeo.momentwo.tag.domain.PhotoTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PhotoTagGenericAdapter implements PhotoTagGenericRepo {
+    private final PhotoTagGenericJpaRepo photoTagGenericJpaRepo;
+
+    @Override
+    public void save(PhotoTag entity) {
+        photoTagGenericJpaRepo.save(entity);
+    }
+
+    @Override
+    public Optional<PhotoTag> findById(Long id) {
+        return photoTagGenericJpaRepo.findById(id);
+    }
+
+    @Override
+    public List<PhotoTag> findAll() {
+        return photoTagGenericJpaRepo.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        photoTagGenericJpaRepo.deleteById(id);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagAddAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagAddAdapter.java
@@ -1,0 +1,32 @@
+package cord.eoeo.momentwo.tag.adapter.out.photo.manager;
+
+import cord.eoeo.momentwo.description.application.port.out.manager.DescriptionGetPhotoPort;
+import cord.eoeo.momentwo.photo.domain.Photo;
+import cord.eoeo.momentwo.tag.advice.exception.NotFoundTagException;
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagAddPort;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+import cord.eoeo.momentwo.tag.domain.PhotoTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagAddAdapter implements PhotoTagAddPort {
+    private final DescriptionGetPhotoPort descriptionGetPhotoPort;
+    private final PhotoTagGenericRepo photoTagGenericRepo;
+    private final AlbumTagGenericRepo albumTagGenericRepo;
+
+    @Override
+    public void PhotoTagAdd(long albumId, long photoId, long albumTagId) {
+        // 설명(작성자) 확인
+        Photo photo = descriptionGetPhotoPort.getPhoto(photoId);
+
+        // 태그정보 확인
+        AlbumTag albumTag = albumTagGenericRepo.findById(albumTagId).orElseThrow(NotFoundTagException::new);
+
+        PhotoTag photoTag = new PhotoTag(photo, albumTag);
+        photoTagGenericRepo.save(photoTag);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagAddAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagAddAdapter.java
@@ -3,9 +3,11 @@ package cord.eoeo.momentwo.tag.adapter.out.photo.manager;
 import cord.eoeo.momentwo.description.application.port.out.manager.DescriptionGetPhotoPort;
 import cord.eoeo.momentwo.photo.domain.Photo;
 import cord.eoeo.momentwo.tag.advice.exception.NotFoundTagException;
+import cord.eoeo.momentwo.tag.advice.exception.TagExceedException;
 import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericRepo;
 import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericRepo;
 import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagAddPort;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagCountPort;
 import cord.eoeo.momentwo.tag.domain.AlbumTag;
 import cord.eoeo.momentwo.tag.domain.PhotoTag;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +19,15 @@ public class PhotoTagAddAdapter implements PhotoTagAddPort {
     private final DescriptionGetPhotoPort descriptionGetPhotoPort;
     private final PhotoTagGenericRepo photoTagGenericRepo;
     private final AlbumTagGenericRepo albumTagGenericRepo;
+    private final PhotoTagCountPort photoTagCountPort;
 
     @Override
     public void PhotoTagAdd(long albumId, long photoId, long albumTagId) {
+        // 20개 확인
+        if(photoTagCountPort.photoTagCount(photoId) >= 20) {
+            throw new TagExceedException();
+        }
+
         // 설명(작성자) 확인
         Photo photo = descriptionGetPhotoPort.getPhoto(photoId);
 

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagCountAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagCountAdapter.java
@@ -1,0 +1,17 @@
+package cord.eoeo.momentwo.tag.adapter.out.photo.manager;
+
+import cord.eoeo.momentwo.tag.application.port.out.photo.jpa.PhotoTagCountRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagCountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagCountAdapter implements PhotoTagCountPort {
+    private final PhotoTagCountRepo photoTagCountRepo;
+
+    @Override
+    public int photoTagCount(long photoId) {
+        return photoTagCountRepo.photoTagCount(photoId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagGetAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagGetAdapter.java
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.tag.adapter.out.photo.manager;
+
+import cord.eoeo.momentwo.tag.application.port.out.photo.jpa.PhotoTagGetJpaRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagGetPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagGetAdapter implements PhotoTagGetPort {
+    private final PhotoTagGetJpaRepo photoTagGetJpaRepo;
+
+    @Override
+    public List<String> photoTagGet(long photoId) {
+        return photoTagGetJpaRepo.photoAllTags(photoId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagRemoveAdapter.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/adapter/out/photo/manager/PhotoTagRemoveAdapter.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.tag.adapter.out.photo.manager;
+
+import cord.eoeo.momentwo.description.application.port.out.manager.DescriptionGetPhotoPort;
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericRepo;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagRemovePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoTagRemoveAdapter implements PhotoTagRemovePort {
+    private final PhotoTagGenericRepo photoTagGenericRepo;
+    private final DescriptionGetPhotoPort descriptionGetPhotoPort;
+
+    @Override
+    public void photoTagRemove(long photoId, long photoTagId) {
+        // 작성자 확인
+        descriptionGetPhotoPort.getPhoto(photoId);
+
+        photoTagGenericRepo.deleteById(photoTagId);
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/advice/TagExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/advice/TagExceptionHandler.java
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.tag.advice;
 
+import cord.eoeo.momentwo.tag.advice.exception.TagExceedException;
 import cord.eoeo.momentwo.tag.advice.exception.TagDuplicateException;
 import cord.eoeo.momentwo.tag.advice.exception.NotFoundTagException;
 import org.springframework.http.HttpStatus;
@@ -19,5 +20,11 @@ public class TagExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public String notFoundTagException() {
         return "태그가 존재하지 않습니다.";
+    }
+
+    @ExceptionHandler(TagExceedException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String tagExceedException() {
+        return "태그는 20개까지 저장 가능합니다.";
     }
 }

--- a/src/main/java/cord/eoeo/momentwo/tag/advice/TagExceptionHandler.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/advice/TagExceptionHandler.java
@@ -1,0 +1,23 @@
+package cord.eoeo.momentwo.tag.advice;
+
+import cord.eoeo.momentwo.tag.advice.exception.TagDuplicateException;
+import cord.eoeo.momentwo.tag.advice.exception.NotFoundTagException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class TagExceptionHandler {
+    @ExceptionHandler(TagDuplicateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public String tagDuplicateException() {
+        return "중복된 태그가 존재합니다";
+    }
+
+    @ExceptionHandler(NotFoundTagException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String notFoundTagException() {
+        return "태그가 존재하지 않습니다.";
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/advice/exception/NotFoundTagException.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/advice/exception/NotFoundTagException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.tag.advice.exception;
+
+public class NotFoundTagException extends RuntimeException {
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/advice/exception/TagDuplicateException.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/advice/exception/TagDuplicateException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.tag.advice.exception;
+
+public class TagDuplicateException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/advice/exception/TagExceedException.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/advice/exception/TagExceedException.java
@@ -1,0 +1,4 @@
+package cord.eoeo.momentwo.tag.advice.exception;
+
+public class TagExceedException extends RuntimeException{
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagCreateUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagCreateUseCase.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.in.album;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagCreateRequestDto;
+
+public interface AlbumTagCreateUseCase {
+    void albumTagCreate(AlbumTagCreateRequestDto albumTagCreateRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagDeleteUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagDeleteUseCase.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.in.album;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagDeleteRequestDto;
+
+public interface AlbumTagDeleteUseCase {
+    void albumTagDelete(AlbumTagDeleteRequestDto albumTagDeleteRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagGetUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagGetUseCase.java
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.tag.application.port.in.album;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagGetRequestDto;
+import cord.eoeo.momentwo.tag.adapter.dto.out.album.AlbumTagGetResponseDto;
+
+public interface AlbumTagGetUseCase {
+    AlbumTagGetResponseDto albumTagGet(AlbumTagGetRequestDto albumTagGetRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagUpdateUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/album/AlbumTagUpdateUseCase.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.in.album;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagUpdateRequestDto;
+
+public interface AlbumTagUpdateUseCase {
+    void albumTagUpdate(AlbumTagUpdateRequestDto albumTagUpdateRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/photo/PhotoTagAddUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/photo/PhotoTagAddUseCase.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.in.photo;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.photo.PhotoTagAddRequestDto;
+
+public interface PhotoTagAddUseCase {
+    void photoTagAdd(PhotoTagAddRequestDto photoTagAddRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/in/photo/PhotoTagRemoveUseCase.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/in/photo/PhotoTagRemoveUseCase.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.in.photo;
+
+import cord.eoeo.momentwo.tag.adapter.dto.in.photo.PhotoTagRemoveRequestDto;
+
+public interface PhotoTagRemoveUseCase {
+    void photoTagRemove(PhotoTagRemoveRequestDto photoTagRemoveRequestDto);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/AlbumTagGenericJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/AlbumTagGenericJpaRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.album;
+
+import cord.eoeo.momentwo.global.application.port.out.GenericDefaultJpaRepo;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+
+public interface AlbumTagGenericJpaRepo extends GenericDefaultJpaRepo<AlbumTag, Long> {
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/AlbumTagGenericRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/AlbumTagGenericRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.album;
+
+import cord.eoeo.momentwo.global.application.port.out.GenericDefaultRepo;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+
+public interface AlbumTagGenericRepo extends GenericDefaultRepo<AlbumTag, Long> {
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagCountRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagCountRepo.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.jpa;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericJpaRepo;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AlbumTagCountRepo extends AlbumTagGenericJpaRepo {
+    @Query("SELECT COUNT(at) FROM AlbumTag at WHERE at.album.id = :albumId")
+    int albumTagCount(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetAlbumIdAndTagRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetAlbumIdAndTagRepo.java
@@ -1,0 +1,12 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.jpa;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericJpaRepo;
+import cord.eoeo.momentwo.tag.domain.AlbumTag;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AlbumTagGetAlbumIdAndTagRepo extends AlbumTagGenericJpaRepo {
+    @Query("SELECT at FROM AlbumTag at WHERE at.album.id = :albumId AND at.tag = :tag")
+    Optional<AlbumTag> getAlbumIdAndTag(long albumId, String tag);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetJpaRepo.java
@@ -1,0 +1,11 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.jpa;
+
+import cord.eoeo.momentwo.tag.application.port.out.album.AlbumTagGenericJpaRepo;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface AlbumTagGetJpaRepo extends AlbumTagGenericJpaRepo {
+    @Query("SELECT at.tag FROM AlbumTag at WHERE at.album.id = :albumId")
+    List<String> allTagByAlbumId(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagCountPort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagCountPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.manager;
+
+public interface AlbumTagCountPort {
+    int albumTagCount(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagDeletePort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagDeletePort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.manager;
+
+public interface AlbumTagDeletePort {
+    void albumTagDelete(long albumTagId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagGetAllTagPort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagGetAllTagPort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.manager;
+
+import java.util.List;
+
+public interface AlbumTagGetAllTagPort {
+    List<String> allTagByAlbumId(long albumId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagSavePort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagSavePort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.manager;
+
+public interface AlbumTagSavePort {
+    void albumTagSave(long albumId, String tag);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagUpdatePort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/manager/AlbumTagUpdatePort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.album.manager;
+
+public interface AlbumTagUpdatePort {
+    void albumTagUpdate(long albumId, long albumTagId, String tag);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/PhotoTagGenericJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/PhotoTagGenericJpaRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo;
+
+import cord.eoeo.momentwo.global.application.port.out.GenericDefaultJpaRepo;
+import cord.eoeo.momentwo.tag.domain.PhotoTag;
+
+public interface PhotoTagGenericJpaRepo extends GenericDefaultJpaRepo<PhotoTag, Long> {
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/PhotoTagGenericRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/PhotoTagGenericRepo.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo;
+
+import cord.eoeo.momentwo.global.application.port.out.GenericDefaultRepo;
+import cord.eoeo.momentwo.tag.domain.PhotoTag;
+
+public interface PhotoTagGenericRepo extends GenericDefaultRepo<PhotoTag, Long> {
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/jpa/PhotoTagCountRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/jpa/PhotoTagCountRepo.java
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.jpa;
+
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericJpaRepo;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PhotoTagCountRepo extends PhotoTagGenericJpaRepo {
+    @Query("SELECT COUNT(pt) FROM PhotoTag pt WHERE pt.photo.id = :photoId")
+    int photoTagCount(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/jpa/PhotoTagGetJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/jpa/PhotoTagGetJpaRepo.java
@@ -1,0 +1,11 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.jpa;
+
+import cord.eoeo.momentwo.tag.application.port.out.photo.PhotoTagGenericJpaRepo;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PhotoTagGetJpaRepo extends PhotoTagGenericJpaRepo {
+    @Query("SELECT pt.albumTag.tag FROM PhotoTag pt WHERE pt.photo.id = :photoId")
+    List<String> photoAllTags(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagAddPort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagAddPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.manager;
+
+public interface PhotoTagAddPort {
+    void PhotoTagAdd(long albumId, long photoId, long albumTagId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagCountPort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagCountPort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.manager;
+
+public interface PhotoTagCountPort {
+    int photoTagCount(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagGetPort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagGetPort.java
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.manager;
+
+import java.util.List;
+
+public interface PhotoTagGetPort {
+    List<String> photoTagGet(long photoId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagRemovePort.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/photo/manager/PhotoTagRemovePort.java
@@ -1,0 +1,5 @@
+package cord.eoeo.momentwo.tag.application.port.out.photo.manager;
+
+public interface PhotoTagRemovePort {
+    void photoTagRemove(long photoId, long photoTagId);
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagCreateService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagCreateService.java
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.tag.application.service.album;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagCreateRequestDto;
+import cord.eoeo.momentwo.tag.application.port.in.album.AlbumTagCreateUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagSavePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumTagCreateService implements AlbumTagCreateUseCase {
+    private final AlbumTagSavePort albumTagSavePort;
+
+    @Override
+    @Transactional
+    @CheckAlbumAccessRules
+    public void albumTagCreate(AlbumTagCreateRequestDto albumTagCreateRequestDto) {
+        albumTagSavePort.albumTagSave(
+                albumTagCreateRequestDto.getAlbumId(),
+                albumTagCreateRequestDto.getTag()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagDeleteService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagDeleteService.java
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.tag.application.service.album;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagDeleteRequestDto;
+import cord.eoeo.momentwo.tag.application.port.in.album.AlbumTagDeleteUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagDeletePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumTagDeleteService implements AlbumTagDeleteUseCase {
+    private final AlbumTagDeletePort albumTagDeletePort;
+
+    @Override
+    @Transactional
+    @CheckAlbumAccessRules
+    public void albumTagDelete(AlbumTagDeleteRequestDto albumTagDeleteRequestDto) {
+        albumTagDeletePort.albumTagDelete(albumTagDeleteRequestDto.getAlbumTagId());
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagGetService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagGetService.java
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.tag.application.service.album;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagGetRequestDto;
+import cord.eoeo.momentwo.tag.adapter.dto.out.album.AlbumTagGetResponseDto;
+import cord.eoeo.momentwo.tag.application.port.in.album.AlbumTagGetUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagGetAllTagPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumTagGetService implements AlbumTagGetUseCase {
+    private final AlbumTagGetAllTagPort albumTagGetAllTagPort;
+
+    @Override
+    @Transactional(readOnly = true)
+    @CheckAlbumAccessRules
+    public AlbumTagGetResponseDto albumTagGet(AlbumTagGetRequestDto albumTagGetRequestDto) {
+        return new AlbumTagGetResponseDto().toDo(
+                albumTagGetAllTagPort.allTagByAlbumId(albumTagGetRequestDto.getAlbumId())
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagUpdateService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/album/AlbumTagUpdateService.java
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.tag.application.service.album;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.album.AlbumTagUpdateRequestDto;
+import cord.eoeo.momentwo.tag.application.port.in.album.AlbumTagUpdateUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.album.manager.AlbumTagUpdatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AlbumTagUpdateService implements AlbumTagUpdateUseCase {
+    private final AlbumTagUpdatePort albumTagUpdatePort;
+
+    @Override
+    @Transactional
+    @CheckAlbumAccessRules
+    public void albumTagUpdate(AlbumTagUpdateRequestDto albumTagUpdateRequestDto) {
+        albumTagUpdatePort.albumTagUpdate(
+                albumTagUpdateRequestDto.getAlbumId(),
+                albumTagUpdateRequestDto.getAlbumTagId(),
+                albumTagUpdateRequestDto.getEditTag()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/photo/PhotoTagAddService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/photo/PhotoTagAddService.java
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.tag.application.service.photo;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.photo.PhotoTagAddRequestDto;
+import cord.eoeo.momentwo.tag.application.port.in.photo.PhotoTagAddUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagAddPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoTagAddService implements PhotoTagAddUseCase {
+    private final PhotoTagAddPort photoTagAddPort;
+
+    @Override
+    @Transactional
+    @CheckAlbumAccessRules
+    public void photoTagAdd(PhotoTagAddRequestDto photoTagAddRequestDto) {
+        photoTagAddPort.PhotoTagAdd(
+                photoTagAddRequestDto.getAlbumId(),
+                photoTagAddRequestDto.getPhotoId(),
+                photoTagAddRequestDto.getAlbumTagId()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/application/service/photo/PhotoTagRemoveService.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/service/photo/PhotoTagRemoveService.java
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.tag.application.service.photo;
+
+import cord.eoeo.momentwo.subAlbum.application.aop.annotation.CheckAlbumAccessRules;
+import cord.eoeo.momentwo.tag.adapter.dto.in.photo.PhotoTagRemoveRequestDto;
+import cord.eoeo.momentwo.tag.application.port.in.photo.PhotoTagRemoveUseCase;
+import cord.eoeo.momentwo.tag.application.port.out.photo.manager.PhotoTagRemovePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoTagRemoveService implements PhotoTagRemoveUseCase {
+    private final PhotoTagRemovePort photoTagRemovePort;
+
+    @Override
+    @Transactional
+    @CheckAlbumAccessRules
+    public void photoTagRemove(PhotoTagRemoveRequestDto photoTagRemoveRequestDto) {
+        photoTagRemovePort.photoTagRemove(
+                photoTagRemoveRequestDto.getPhotoId(),
+                photoTagRemoveRequestDto.getPhotoTagId()
+        );
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/domain/AlbumTag.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/domain/AlbumTag.java
@@ -1,0 +1,33 @@
+package cord.eoeo.momentwo.tag.domain;
+
+import cord.eoeo.momentwo.album.domain.Album;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class AlbumTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "album")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Album album;
+
+    @Column(nullable = false, name = "tag")
+    private String tag;
+
+    public AlbumTag(Album album, String tag) {
+        this.album = album;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/cord/eoeo/momentwo/tag/domain/PhotoTag.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/domain/PhotoTag.java
@@ -1,0 +1,35 @@
+package cord.eoeo.momentwo.tag.domain;
+
+import cord.eoeo.momentwo.photo.domain.Photo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PhotoTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "photo")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Photo photo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "albumTag")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private AlbumTag albumTag;
+
+    public PhotoTag(Photo photo, AlbumTag albumTag) {
+        this.photo = photo;
+        this.albumTag = albumTag;
+    }
+}


### PR DESCRIPTION
### 태그 테이블 생성 및 기능 구현
- ~~앨범 태그 테이블, 사진 태그 테이블, 태그 테이블 총 3개로 구현~~
- ~~앨범 태그 -> 태그 테이블, 사진 태그 -> 태그 테이블에 의존~~
- 앨범 태그 테이블, 사진 태그 테이블 총 2개로 구현
- 사진 태그 -> 앨범 태그 의존

### 앨범 태그
- 권한 : 앨범 접근 권한
- 앨범 태그 20개 제한
- 앨범 태그 생성, 앨범 태그 조회, 앨범 태그 수정, 앨범 태그 삭제

### 사진 태그
- 권한 : 앨범 접근 권한
- 사진 태그 20개 제한
- 사진 태그 생성(작성자만)
- ~~사진 태그 조회(모두)~~ -> 설명 조회에서 같이 반환
- ~~사진 태그 수정(작성자만)~~ -> 삭제 후 생성 하는 방식으로 진행
- 사진 태그 삭제(작성자만)

Resolve: #279 