### PR TITLE
앨범 태그 에러수정

### DIFF
--- a/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetJpaRepo.java
+++ b/src/main/java/cord/eoeo/momentwo/tag/application/port/out/album/jpa/AlbumTagGetJpaRepo.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface AlbumTagGetJpaRepo extends AlbumTagGenericJpaRepo {
-    @Query("SELECT new cord.eoeo.momentwo.tag.adapter.dto.out.album.AlbumTagResponseDto(at.id, at.tag) FROM AlbumTag at WHERE at.album.id = :albumId")
+    @Query("SELECT new cord.eoeo.momentwo.tag.adapter.dto.out.album.AlbumTagQueryDto(at.id, at.tag) FROM AlbumTag at WHERE at.album.id = :albumId")
     List<AlbumTagQueryDto> allTagByAlbumId(long albumId);
 }


### PR DESCRIPTION
### 앨범 태그 에러수정
- 쿼리문에 직접 선언한 DTO 명칭 미변경으로 인한 에러 수정

Resolve: #300